### PR TITLE
Add Server-Timing header

### DIFF
--- a/live.tsx
+++ b/live.tsx
@@ -6,16 +6,14 @@ import { DecoManifest, LiveOptions } from "$live/types.ts";
 import InspectVSCodeHandler from "https://deno.land/x/inspect_vscode@0.0.5/handler.ts";
 import getSupabaseClient from "./supabase.ts";
 import { authHandler } from "./auth.tsx";
+import { createServerTiming } from "./utils/serverTimings.ts";
 
 // While Fresh doesn't allow for injecting routes and middlewares,
 // we have to deliberately store the manifest in this scope.
 let userManifest: DecoManifest;
 let userOptions: LiveOptions;
 
-export const setupLive = (
-  manifest: DecoManifest,
-  liveOptions: LiveOptions,
-) => {
+export const setupLive = (manifest: DecoManifest, liveOptions: LiveOptions) => {
   userManifest = manifest;
   userOptions = liveOptions;
 };
@@ -30,10 +28,7 @@ interface LivePageData {
 export interface LivePageOptions<Data = unknown> {
   template?: string;
   render?: (props: PageProps<LivePageData & Data>) => any;
-  loader?: (
-    req: Request,
-    ctx: HandlerContext<Data>,
-  ) => Promise<Data>;
+  loader?: (req: Request, ctx: HandlerContext<Data>) => Promise<Data>;
 }
 
 export function createLivePage<Data>(options: LivePageOptions<Data>) {
@@ -41,14 +36,14 @@ export function createLivePage<Data>(options: LivePageOptions<Data>) {
 
   const handler: Handlers<LivePageData> = {
     async GET(req, ctx) {
-      console.log(req, ctx);
+      const { start, end, printTimings } = createServerTiming();
       const url = new URL(req.url);
       const site = userOptions.site;
       const domains: string[] = userOptions.domains || [];
       domains.push(
         `${site}.deco.page`,
         `deco-pages-${site}.deno.dev`,
-        `localhost`,
+        `localhost`
       );
 
       if (!domains.includes(url.hostname)) {
@@ -59,11 +54,13 @@ export function createLivePage<Data>(options: LivePageOptions<Data>) {
         return new Response("Site not found", { status: 404 });
       }
 
+      start("fetch-page-data");
       let { data: Pages, error } = await getSupabaseClient()
         .from("Pages")
         .select(`components, path, site!inner(name, id)`)
         .eq("site.name", site)
         .eq("path", url.pathname);
+      end("fetch-page-data");
 
       if (error) {
         console.log("Error fetching page:", error);
@@ -71,13 +68,24 @@ export function createLivePage<Data>(options: LivePageOptions<Data>) {
         console.log("Found page:", Pages);
       }
 
-      const components = Pages && Pages[0]?.components || null;
+      const components = (Pages && Pages[0]?.components) || null;
+
+      start("run-page-loader")
       const loader = await options.loader?.(req, ctx);
+      end("run-page-loader")
+
       const data = {
         components,
         loader,
       };
-      return ctx.render(data);
+
+      start("render");
+      const res = await ctx.render(data);
+      end("render");
+
+      res.headers.set("Server-Timing", printTimings());
+
+      return res;
     },
     async POST(req, ctx) {
       const url = new URL(req.url);
@@ -91,22 +99,25 @@ export function createLivePage<Data>(options: LivePageOptions<Data>) {
     },
   };
 
-  function LivePage(
-    props: PageProps<LivePageData & Data>,
-  ) {
+  function LivePage(props: PageProps<LivePageData & Data>) {
     const manifest = userManifest;
     const { data } = props;
     const { components } = data;
-    const renderComponents = components && components.length > 0
-      ? components.map(({ component, props }: any) => {
-        const Comp = manifest.islands[`./islands/${component}.tsx`]?.default ||
-          manifest.components![`./components/${component}.tsx`]?.default;
-        return <Comp {...props} />;
-      })
-      : defaultRender
-      ? defaultRender(props)
-      : <div>Page not found</div>;
-    const InspectVSCode = !isDenoDeploy &&
+    const renderComponents =
+      components && components.length > 0 ? (
+        components.map(({ component, props }: any) => {
+          const Comp =
+            manifest.islands[`./islands/${component}.tsx`]?.default ||
+            manifest.components![`./components/${component}.tsx`]?.default;
+          return <Comp {...props} />;
+        })
+      ) : defaultRender ? (
+        defaultRender(props)
+      ) : (
+        <div>Page not found</div>
+      );
+    const InspectVSCode =
+      !isDenoDeploy &&
       userManifest.islands[`./islands/InspectVSCode.tsx`]?.default;
     return (
       <>

--- a/utils/serverTimings.ts
+++ b/utils/serverTimings.ts
@@ -1,0 +1,25 @@
+type Timing = { start: number; end?: number };
+
+export function createServerTiming() {
+  const timings: Record<string, Timing> = {};
+  const start = (key: string) => {
+    timings[key] = { start: Date.now() };
+  };
+  const end = (key: string) => {
+    timings[key].end = Date.now();
+  };
+
+  const printTimings = () => {
+    return Object.entries(timings)
+      .map(([key, timing]) => {
+        return `${key};dur=${timing.end - timing.start}`;
+      })
+      .join(", ");
+  };
+
+  return {
+    start,
+    end,
+    printTimings,
+  };
+}


### PR DESCRIPTION
# Context
Have information about rendering phases.

This PR adds a Server-Timing header to the live GET response.

![image](https://user-images.githubusercontent.com/15680320/183686196-740e4020-8c65-4fe7-b9a7-c2cd41b72d3d.png)
