### PR TITLE
feat: List Components Preview

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -9,6 +9,8 @@ let liveOptions: EnhancedLiveOptions;
 const defaultDomains = [
   `localhost`,
 ];
+const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");
+const _isDenoDeploy = deploymentId !== undefined;
 
 export function getDefaultDomains() {
   return defaultDomains;
@@ -36,4 +38,12 @@ export function getLiveOptions() {
 
 export function setLiveOptions(newLiveOptions: EnhancedLiveOptions) {
   liveOptions = newLiveOptions;
+}
+
+export function getDeploymentId() {
+  return deploymentId;
+}
+
+export function isDenoDeploy() {
+  return _isDenoDeploy;
 }

--- a/context.ts
+++ b/context.ts
@@ -18,6 +18,10 @@ export function pushDefaultDomains(...domains: string[]) {
   defaultDomains.push(...domains);
 }
 
+export function isPrivateDomain(domain: string) {
+  return defaultDomains.includes(domain);
+}
+
 export function getManifest() {
   return manifest;
 }

--- a/context.ts
+++ b/context.ts
@@ -1,0 +1,35 @@
+import type { DecoManifest, LiveOptions } from "./types.ts";
+
+type EnhancedLiveOptions = LiveOptions & { siteId?: number };
+
+// While Fresh doesn't allow for injecting routes and middlewares,
+// we have to deliberately store the manifest in this scope.
+let manifest: DecoManifest;
+let liveOptions: EnhancedLiveOptions;
+const defaultDomains = [
+  `localhost`,
+];
+
+export function getDefaultDomains() {
+  return defaultDomains;
+}
+
+export function pushDefaultDomains(...domains: string[]) {
+  defaultDomains.push(...domains);
+}
+
+export function getManifest() {
+  return manifest;
+}
+
+export function setManifest(newManifest: DecoManifest) {
+  manifest = newManifest;
+}
+
+export function getLiveOptions() {
+  return liveOptions;
+}
+
+export function setLiveOptions(newLiveOptions: EnhancedLiveOptions) {
+  liveOptions = newLiveOptions;
+}

--- a/context.ts
+++ b/context.ts
@@ -2,48 +2,71 @@ import type { DecoManifest, LiveOptions } from "./types.ts";
 
 type EnhancedLiveOptions = LiveOptions & { siteId?: number };
 
-// While Fresh doesn't allow for injecting routes and middlewares,
-// we have to deliberately store the manifest in this scope.
-let manifest: DecoManifest;
-let liveOptions: EnhancedLiveOptions;
-const defaultDomains = [
-  `localhost`,
-];
-const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");
-const _isDenoDeploy = deploymentId !== undefined;
+class LiveContext {
+  // While Fresh doesn't allow for injecting routes and middlewares,
+  // we have to deliberately store the manifest in this scope.
+  #manifest: DecoManifest;
+  #liveOptions: EnhancedLiveOptions;
+  #defaultDomains: string[];
+  #deploymentId: string | undefined;
+  #isDenoDeploy: boolean;
 
-export function getDefaultDomains() {
-  return defaultDomains;
+  constructor() {
+    this.#deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");
+    this.#isDenoDeploy = this.#deploymentId !== undefined;
+    this.#defaultDomains = ["localhost"];
+  }
+
+  public setupManifestAndOptions({ manifest, liveOptions }: {
+    manifest: DecoManifest;
+    liveOptions: EnhancedLiveOptions;
+  }) {
+    if (!this.#manifest) {
+      this.setManifest(manifest);
+    }
+
+    if (!this.#liveOptions) {
+      this.setLiveOptions(liveOptions);
+    }
+  }
+
+  public getDefaultDomains() {
+    return this.#defaultDomains;
+  }
+
+  public pushDefaultDomains(...domains: string[]) {
+    this.#defaultDomains.push(...domains);
+  }
+
+  public isPrivateDomain(domain: string) {
+    return this.#defaultDomains.includes(domain);
+  }
+
+  public getManifest() {
+    return this.#manifest;
+  }
+
+  public setManifest(manifest: DecoManifest) {
+    this.#manifest = manifest;
+  }
+
+  public getLiveOptions() {
+    return this.#liveOptions;
+  }
+
+  public setLiveOptions(liveOptions: EnhancedLiveOptions) {
+    this.#liveOptions = liveOptions;
+  }
+
+  public getDeploymentId() {
+    return this.#deploymentId;
+  }
+
+  public isDenoDeploy() {
+    return this.#isDenoDeploy;
+  }
 }
 
-export function pushDefaultDomains(...domains: string[]) {
-  defaultDomains.push(...domains);
-}
+const liveContext: LiveContext = new LiveContext();
 
-export function isPrivateDomain(domain: string) {
-  return defaultDomains.includes(domain);
-}
-
-export function getManifest() {
-  return manifest;
-}
-
-export function setManifest(newManifest: DecoManifest) {
-  manifest = newManifest;
-}
-
-export function getLiveOptions() {
-  return liveOptions;
-}
-
-export function setLiveOptions(newLiveOptions: EnhancedLiveOptions) {
-  liveOptions = newLiveOptions;
-}
-
-export function getDeploymentId() {
-  return deploymentId;
-}
-
-export function isDenoDeploy() {
-  return _isDenoDeploy;
-}
+export default liveContext;

--- a/dev.ts
+++ b/dev.ts
@@ -3,13 +3,11 @@ import { dirname, fromFileUrl, join, toFileUrl } from "std/path/mod.ts";
 import "std/dotenv/load.ts";
 import { collect } from "$fresh/src/dev/mod.ts";
 import { walk } from "std/fs/walk.ts";
-
-const COMPONENT_NAME_REGEX = /^\/(\w*)\.(tsx|jsx|js|ts)/;
-
-const BLOCKED_ISLANDS_SCHEMAS = new Set([
-  "/Editor.tsx",
-  "/InspectVSCode.tsx",
-]);
+import {
+  COMPONENT_NAME_REGEX,
+  componentNameFromPath,
+  isValidIsland,
+} from "./utils/component.ts";
 
 interface DevManifest {
   routes: string[];
@@ -84,14 +82,14 @@ async function collectComponentsSchemas(
     const schema = componentFile.schema ?? null;
 
     return {
-      component: componentName.replace(COMPONENT_NAME_REGEX, "$1"),
+      component: componentNameFromPath(componentName),
       schema,
     };
   };
 
   const componentsSchemas: Promise<SchemaMap>[] = [];
   islands.forEach((islandName) => {
-    if (BLOCKED_ISLANDS_SCHEMAS.has(islandName)) {
+    if (!isValidIsland(islandName)) {
       return;
     }
 

--- a/editor.tsx
+++ b/editor.tsx
@@ -9,6 +9,7 @@ import {
   getComponentModule,
 } from "./utils/component.ts";
 import { createServerTiming } from "./utils/serverTimings.ts";
+import { h } from "preact";
 
 const ONE_YEAR_CACHE = "public, max-age=31536000, immutable";
 
@@ -136,10 +137,50 @@ export function renderComponent(
     });
   }
 
-  let html: string;
+  let html = "";
   start("render-component");
-  try {
+
+  const render = () => {
     html = renderToString(<Component />);
+
+    // TODO: handle hydration
+    // https://github.com/denoland/fresh/blob/1b3c9f2569c5d56a6d37c366cb5940f26b7e131e/plugins/twind.ts#L24
+
+    return {
+      htmlText: html,
+      requiresHydration: false,
+    };
+  };
+
+  const twindPlugin = LiveContext.getLiveOptions().plugins?.find((plugin) => {
+    return plugin.name === "twind";
+  });
+
+  try {
+    if (twindPlugin) {
+      // Mimic the fresh render function that run plugins.render
+      // https://github.com/denoland/fresh/blob/main/src/server/render.ts#L174
+      const res = twindPlugin.render?.({
+        render,
+      }) ?? {};
+
+      if (res.styles) {
+        const [style] = res.styles;
+
+        const styleNode = (
+          <style
+            id={style.id}
+            dangerouslySetInnerHTML={{ __html: style.cssText }}
+            media={style.media}
+          />
+        );
+
+        const styleString = renderToString(styleNode);
+        html = styleString + html;
+      }
+    } else {
+      render();
+    }
   } catch (e) {
     if (url.hostname === "localhost") {
       throw e;

--- a/editor.tsx
+++ b/editor.tsx
@@ -1,9 +1,9 @@
 import { HandlerContext } from "$fresh/server.ts";
 import { renderToString } from "preact-render-to-string";
 import {
-  getDefaultDomains,
   getLiveOptions,
   getManifest,
+  isDenoDeploy,
   isPrivateDomain,
 } from "./context.ts";
 import { getSupabaseClientForUser } from "./supabase.ts";
@@ -14,6 +14,10 @@ import {
   isValidIsland,
 } from "./utils/component.ts";
 import { createServerTiming } from "./utils/serverTimings.ts";
+
+const ONE_MINUTE = 60;
+const ONE_HOUR = 60 * ONE_MINUTE;
+const ONE_DAY = 24 * ONE_HOUR;
 
 export async function updateComponentProps(
   req: Request,
@@ -97,6 +101,13 @@ export function componentsPreview(
     headers: {
       "content-type": "application/json",
       "Server-Timing": printTimings(),
+      ...(isDenoDeploy()
+        ? {
+          "Cache-Control": `max-age=${ONE_DAY}, stale-while-revalidate=${
+            15 * ONE_MINUTE
+          }`,
+        }
+        : {}),
     },
   });
 }
@@ -127,6 +138,13 @@ export function renderComponent(
       headers: {
         "content-type": "text/html; charset=utf-8",
         "Server-Timing": printTimings(),
+        ...(isDenoDeploy()
+          ? {
+            "Cache-Control": `max-age=${ONE_DAY}, stale-while-revalidate=${
+              15 * ONE_MINUTE
+            }`,
+          }
+          : {}),
       },
     },
   );

--- a/editor.tsx
+++ b/editor.tsx
@@ -9,10 +9,8 @@ import {
 import { getSupabaseClientForUser } from "./supabase.ts";
 import { Module } from "./types.ts";
 import {
-  COMPONENT_NAME_REGEX,
   componentNameFromPath,
   getComponentModule,
-  isValidIsland,
 } from "./utils/component.ts";
 import { createServerTiming } from "./utils/serverTimings.ts";
 
@@ -133,7 +131,7 @@ export function renderComponent(
 
   const { start, end, printTimings } = createServerTiming();
 
-  const componentName = url.pathname.split("/").pop() ?? "";
+  const componentName = url.pathname.replace("/live/api/components/", "") ?? "";
   const manifest = getManifest();
   const Component = getComponentModule(manifest, componentName)?.default;
 

--- a/editor.tsx
+++ b/editor.tsx
@@ -101,7 +101,7 @@ export function componentsPreview(
   const cache = LiveContext.isDenoDeploy() &&
     url.searchParams.has(ASSET_CACHE_BUST_KEY);
 
-  return new Response(JSON.stringify({ components, islands }), {
+  return Response.json({ components, islands }, {
     status: 200,
     headers: {
       "content-type": "application/json",
@@ -131,7 +131,7 @@ export function renderComponent(
   const Component = getComponentModule(manifest, componentName)?.default;
 
   if (!Component) {
-    return new Response(JSON.stringify({ error: "Component Not Found" }), {
+    return new Response("Component Not Found", {
       status: 404,
     });
   }

--- a/import_map.json
+++ b/import_map.json
@@ -5,6 +5,7 @@
     "preact": "https://esm.sh/preact@10.10.6",
     "preact/": "https://esm.sh/preact@10.10.6/",
     "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.0?deps=preact@10.10.6",
+    "tabbable": "https://esm.sh/v91/tabbable@5.3.3/",
     "twind": "https://esm.sh/twind@0.16.17",
     "twind/": "https://esm.sh/twind@0.16.17/",
     "partytown": "https://esm.sh/@builder.io/partytown@0.7.0/integration",

--- a/live.tsx
+++ b/live.tsx
@@ -16,7 +16,7 @@ import {
 } from "$live/editor.tsx";
 import EditorListener from "./src/EditorListener.tsx";
 import { getComponentModule } from "./utils/component.ts";
-import type { ComponentType } from "preact";
+import type { ComponentChildren, ComponentType } from "preact";
 import type { Props as EditorProps } from "./src/Editor.tsx";
 import {
   getDefaultDomains,
@@ -222,7 +222,11 @@ export function LiveComponents(
   );
 }
 
-export function LivePage({ data, ...otherProps }: PageProps<LivePageData>) {
+export function LivePage(
+  { data, children, ...otherProps }: PageProps<LivePageData> & {
+    children: ComponentChildren;
+  },
+) {
   const manifest = getManifest();
   const InspectVSCode = !isDenoDeploy &&
     manifest.islands[`./islands/InspectVSCode.tsx`]?.default;
@@ -240,7 +244,7 @@ export function LivePage({ data, ...otherProps }: PageProps<LivePageData>) {
 
   return (
     <div class="flex">
-      <LiveComponents {...data} />
+      {children ? children : <LiveComponents {...data} />}
       {renderEditor && privateDomain
         ? (
           <Editor

--- a/live.tsx
+++ b/live.tsx
@@ -20,16 +20,15 @@ import type { ComponentChildren, ComponentType } from "preact";
 import type { Props as EditorProps } from "./src/Editor.tsx";
 import {
   getDefaultDomains,
+  getDeploymentId,
   getLiveOptions,
   getManifest,
+  isDenoDeploy,
   isPrivateDomain,
   pushDefaultDomains,
   setLiveOptions,
   setManifest,
 } from "./context.ts";
-
-const deploymentId = Deno.env.get("DENO_DEPLOYMENT_ID");
-const isDenoDeploy = deploymentId !== undefined;
 
 export const setupLive = (manifest: DecoManifest, liveOptions: LiveOptions) => {
   setManifest(manifest);
@@ -40,9 +39,9 @@ export const setupLive = (manifest: DecoManifest, liveOptions: LiveOptions) => {
   );
 
   // Support deploy preview domains
-  if (deploymentId) {
+  if (isDenoDeploy()) {
     pushDefaultDomains(
-      `deco-pages-${liveOptions.site}-${deploymentId}.deno.dev`,
+      `deco-pages-${liveOptions.site}-${getDeploymentId()}.deno.dev`,
     );
   }
 

--- a/live.tsx
+++ b/live.tsx
@@ -171,14 +171,9 @@ export function createLiveHandler<LoaderData = LivePageData>(
         const options = { userOptions };
         return await updateComponentProps(req, ctx, options);
       }
+      // TODO: change this to GET
       if (url.pathname === "/live/api/components") {
-        // TODO: change this to GET
-        const components = componentsPreview(userManifest);
-
-        return new Response(JSON.stringify({ components }), {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        });
+        return componentsPreview(userManifest);
       }
       return new Response("Not found", { status: 404 });
     },

--- a/live.tsx
+++ b/live.tsx
@@ -124,15 +124,13 @@ export function createLiveHandler<LoaderData = LivePageData>(
       // TODO: Find a better way to embedded this route on project routes.
       // Follow up here: https://github.com/denoland/fresh/issues/516
       if (url.pathname === "/live/api/components") {
-        return componentsPreview(url);
+        return componentsPreview(req);
       }
 
       if (
         url.pathname.startsWith("/live/api/components/")
       ) {
-        const componentName = url.pathname.split("/").pop() ?? "";
-
-        return renderComponent(url, componentName);
+        return renderComponent(req);
       }
 
       const { start, end, printTimings } = createServerTiming();

--- a/live.tsx
+++ b/live.tsx
@@ -123,15 +123,11 @@ export function createLiveHandler<LoaderData = LivePageData>(
       const url = new URL(req.url);
       // TODO: Find a better way to embedded this route on project routes.
       // Follow up here: https://github.com/denoland/fresh/issues/516
-      // TODO: Protect these endpoints
       if (url.pathname === "/live/api/components") {
-        return componentsPreview(url, "components");
+        return componentsPreview(url);
       }
-      if (url.pathname === "/live/api/islands") {
-        return componentsPreview(url, "islands");
-      }
+
       if (
-        url.pathname.startsWith("/live/api/islands/") ||
         url.pathname.startsWith("/live/api/components/")
       ) {
         const componentName = url.pathname.split("/").pop() ?? "";

--- a/live.tsx
+++ b/live.tsx
@@ -22,6 +22,7 @@ import {
   getDefaultDomains,
   getLiveOptions,
   getManifest,
+  isPrivateDomain,
   pushDefaultDomains,
   setLiveOptions,
   setManifest,
@@ -51,10 +52,6 @@ export const setupLive = (manifest: DecoManifest, liveOptions: LiveOptions) => {
     domains: [...getDefaultDomains(), ...userDomains],
   });
 };
-
-function isPrivateDomain(domain: string) {
-  return getDefaultDomains().includes(domain);
-}
 
 export interface LivePageData {
   components: PageComponentData[];
@@ -129,10 +126,10 @@ export function createLiveHandler<LoaderData = LivePageData>(
       // Follow up here: https://github.com/denoland/fresh/issues/516
       // TODO: Protect these endpoints
       if (url.pathname === "/live/api/components") {
-        return componentsPreview("components");
+        return componentsPreview(url, "components");
       }
       if (url.pathname === "/live/api/islands") {
-        return componentsPreview("islands");
+        return componentsPreview(url, "islands");
       }
       if (
         url.pathname.startsWith("/live/api/islands/") ||
@@ -140,7 +137,7 @@ export function createLiveHandler<LoaderData = LivePageData>(
       ) {
         const componentName = url.pathname.split("/").pop() ?? "";
 
-        return renderComponent(componentName);
+        return renderComponent(url, componentName);
       }
 
       const { start, end, printTimings } = createServerTiming();

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -1,0 +1,35 @@
+import { tw } from "twind";
+import { useState } from "preact/hooks";
+import PlusIcon from "./icons/PlusIcon.tsx";
+import Button from "./ui/Button.tsx";
+import Modal from "./ui/Modal.tsx";
+import { useEditor } from "./EditorProvider.tsx";
+
+interface Props {
+  onAddComponent: (componentName: string) => void;
+}
+
+export default function AddNewComponent({ onAddComponent }: Props) {
+  const [openModal, setOpenModal] = useState<boolean>(false);
+  const { componentSchemas } = useEditor();
+
+  return (
+    <>
+      <Button
+        class="w-full flex justify-center"
+        onClick={() => setOpenModal(true)}
+      >
+        <PlusIcon />
+      </Button>
+      {openModal && (
+        <Modal
+          open={openModal}
+          onDismiss={() => setOpenModal(false)}
+          class={tw`container rounded bg-white p-5 h-5/6`}
+        >
+          {JSON.stringify(componentSchemas)}
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -1,4 +1,3 @@
-import { tw } from "twind";
 import { useEffect, useRef, useState } from "preact/hooks";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
@@ -10,7 +9,7 @@ function ToCItem({ component, componentLabel }: ComponentPreview) {
   return (
     <li key={component}>
       <a
-        class={tw`font-medium  text-gray-500 hover:text-black`}
+        class="font-medium  text-gray-500 hover:text-black"
         href={`#${component}`}
       >
         {componentLabel}
@@ -75,18 +74,18 @@ export default function AddNewComponent({ onAddComponent }: Props) {
       <Modal
         open={openModal}
         onDismiss={() => setOpenModal(false)}
-        class={tw`container rounded bg-white p-5`}
+        class="container rounded bg-white p-5"
       >
         <div class="w-full flex justify-between mb-4">
-          <span class={tw`text-xl font-bold`}>Componentes</span>
+          <span class="text-xl font-bold">Componentes</span>
           <Button onClick={() => setOpenModal(false)}>
-            <PlusIcon class={tw`rotate-45`} />
+            <PlusIcon class="rotate-45" />
           </Button>
         </div>
 
-        <div class={tw`flex`}>
+        <div class="flex">
           <div
-            class={tw`overflow-y-auto max-h-[80vh] h-[80vh] w-full`}
+            class="overflow-y-auto max-h-[80vh] h-[80vh] w-full"
             ref={targetRef}
           >
             <ComponentPreviewList
@@ -98,7 +97,7 @@ export default function AddNewComponent({ onAddComponent }: Props) {
             />
           </div>
           <nav
-            class={tw`ml-4 px-4 border-l w-1/6`}
+            class="ml-4 px-4 border-l w-1/6"
             aria-label="Table of components"
           >
             <ul>

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -1,12 +1,10 @@
 import { tw } from "twind";
-import { useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
 import Modal from "./ui/Modal.tsx";
 import ComponentPreviewList from "./ComponentPreviewList.tsx";
 import type { ComponentPreview } from "../editor.tsx";
-
-type ToCState = { islands: ComponentPreview[]; components: ComponentPreview[] };
 
 function ToCItem({ component, componentLabel }: ComponentPreview) {
   return (
@@ -26,16 +24,44 @@ interface Props {
 }
 
 export default function AddNewComponent({ onAddComponent }: Props) {
+  const targetRef = useRef<HTMLDivElement>(null);
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [tocComponents, setToCComponents] = useState<
-    ToCState
-  >({ islands: [], components: [] });
-  const registerToC = (newToC: Partial<ToCState>) => {
-    setToCComponents((oldToCComponents) => ({
-      ...oldToCComponents,
-      ...newToC,
-    }));
-  };
+    ComponentPreview[]
+  >([]);
+
+  useEffect(function initObserverIframes() {
+    if (!targetRef.current || !(openModal && tocComponents.length > 0)) {
+      return;
+    }
+
+    const target = targetRef.current;
+
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.intersectionRatio > 0) {
+          const iframe = (entry.target as HTMLIFrameElement);
+
+          // Prevent set the src and make the browser fetch the page multiple times
+          if (!iframe.src) {
+            iframe.src = iframe.dataset.src ?? "";
+          }
+        }
+      });
+    }, {
+      root: target,
+    });
+
+    const iframes = target.getElementsByTagName("iframe");
+    for (const iframe of iframes) {
+      observer.observe(iframe);
+    }
+
+    return () => {
+      observer.disconnect();
+    };
+    // tocComponents are the components fetched by the ComponentsPreviewList and they doesn't exist when openModal = true at the first time
+  }, [openModal, tocComponents]);
 
   return (
     <>
@@ -59,9 +85,12 @@ export default function AddNewComponent({ onAddComponent }: Props) {
         </div>
 
         <div class={tw`flex`}>
-          <div class={tw`overflow-y-auto max-h-[80vh] h-[80vh] w-full`}>
+          <div
+            class={tw`overflow-y-auto max-h-[80vh] h-[80vh] w-full`}
+            ref={targetRef}
+          >
             <ComponentPreviewList
-              registerToC={registerToC}
+              registerToC={setToCComponents}
               onClickComponent={(componentName) => {
                 onAddComponent(componentName);
                 setOpenModal(false);
@@ -73,10 +102,7 @@ export default function AddNewComponent({ onAddComponent }: Props) {
             aria-label="Table of components"
           >
             <ul>
-              {tocComponents.components.map((
-                props,
-              ) => <ToCItem key={props.component} {...props} />)}
-              {tocComponents.islands.map((
+              {tocComponents.map((
                 props,
               ) => <ToCItem key={props.component} {...props} />)}
             </ul>

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -31,7 +31,6 @@ export default function AddNewComponent({ onAddComponent }: Props) {
     ToCState
   >({ islands: [], components: [] });
   const registerToC = (newToC: Partial<ToCState>) => {
-    console.log("New ToC", newToC);
     setToCComponents((oldToCComponents) => ({
       ...oldToCComponents,
       ...newToC,

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useRef, useState } from "preact/hooks";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
 import Modal from "./ui/Modal.tsx";
@@ -28,39 +28,6 @@ export default function AddNewComponent({ onAddComponent }: Props) {
   const [tocComponents, setToCComponents] = useState<
     ComponentPreview[]
   >([]);
-
-  useEffect(function initObserverIframes() {
-    if (!targetRef.current || !(openModal && tocComponents.length > 0)) {
-      return;
-    }
-
-    const target = targetRef.current;
-
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.intersectionRatio > 0) {
-          const iframe = (entry.target as HTMLIFrameElement);
-
-          // Prevent set the src and make the browser fetch the page multiple times
-          if (!iframe.src) {
-            iframe.src = iframe.dataset.src ?? "";
-          }
-        }
-      });
-    }, {
-      root: target,
-    });
-
-    const iframes = target.getElementsByTagName("iframe");
-    for (const iframe of iframes) {
-      observer.observe(iframe);
-    }
-
-    return () => {
-      observer.disconnect();
-    };
-    // tocComponents are the components fetched by the ComponentsPreviewList and they doesn't exist when openModal = true at the first time
-  }, [openModal, tocComponents]);
 
   return (
     <>

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -3,8 +3,7 @@ import { useState } from "preact/hooks";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
 import Modal from "./ui/Modal.tsx";
-import { useEditor } from "./EditorProvider.tsx";
-import { IS_BROWSER } from "https://deno.land/x/fresh@1.1.0/src/runtime/utils.ts";
+import ComponentPreviewList from "./ComponentPreviewList.tsx";
 
 interface Props {
   onAddComponent: (componentName: string) => void;
@@ -12,14 +11,6 @@ interface Props {
 
 export default function AddNewComponent({ onAddComponent }: Props) {
   const [openModal, setOpenModal] = useState<boolean>(false);
-  const [components, setComponents] = useState<
-    { html: string; componentLabel: string; component: string }[] | undefined
-  >(undefined);
-
-  if (IS_BROWSER && !components) {
-    fetch("/live/api/components", { method: "POST" }).then((res) => res.json())
-      .then(({ components: apiComponents }) => setComponents(apiComponents));
-  }
 
   return (
     <>
@@ -34,36 +25,21 @@ export default function AddNewComponent({ onAddComponent }: Props) {
         <Modal
           open={openModal}
           onDismiss={() => setOpenModal(false)}
-          class={tw`container rounded bg-white p-5 h-5/6 overflow-y-auto`}
+          class={tw`container rounded bg-white p-5 max-h-[83.33%] overflow-y-auto`}
         >
           <div>
-            {components?.map(({ html, component, componentLabel }, index) => {
-              return (
-                <>
-                  <label>{componentLabel}</label>
-                  <div class="relative border rounded">
-                    <iframe
-                      srcDoc={`<!DOCTYPE html>${html}`}
-                      key={index}
-                      class={tw`h-[200px] max-h-[250px] w-full`}
-                    />
-                    <div
-                      class={tw`group flex items-center justify-center absolute inset-0 z-50 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors easy-in`}
-                      onClick={() => {
-                        onAddComponent(component);
-                        setOpenModal(false);
-                      }}
-                    >
-                      <PlusIcon
-                        width={32}
-                        height={32}
-                        class={tw`hidden group-hover:block text-gray-400`}
-                      />
-                    </div>
-                  </div>
-                </>
-              );
-            })}
+            <div class="w-full flex justify-between mb-4">
+              <span class={tw`text-xl font-bold`}>Componentes</span>
+              <Button onClick={() => setOpenModal(false)}>
+                <PlusIcon class={tw`rotate-45`} />
+              </Button>
+            </div>
+            <ComponentPreviewList
+              onClickComponent={(componentName) => {
+                onAddComponent(componentName);
+                setOpenModal(false);
+              }}
+            />
           </div>
         </Modal>
       )}

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -4,6 +4,7 @@ import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
 import Modal from "./ui/Modal.tsx";
 import { useEditor } from "./EditorProvider.tsx";
+import { IS_BROWSER } from "https://deno.land/x/fresh@1.1.0/src/runtime/utils.ts";
 
 interface Props {
   onAddComponent: (componentName: string) => void;
@@ -11,7 +12,14 @@ interface Props {
 
 export default function AddNewComponent({ onAddComponent }: Props) {
   const [openModal, setOpenModal] = useState<boolean>(false);
-  const { componentSchemas } = useEditor();
+  const [components, setComponents] = useState<
+    { html: string; componentLabel: string; component: string }[] | undefined
+  >(undefined);
+
+  if (IS_BROWSER && !components) {
+    fetch("/live/api/components", { method: "POST" }).then((res) => res.json())
+      .then(({ components: apiComponents }) => setComponents(apiComponents));
+  }
 
   return (
     <>
@@ -21,13 +29,42 @@ export default function AddNewComponent({ onAddComponent }: Props) {
       >
         <PlusIcon />
       </Button>
+
       {openModal && (
         <Modal
           open={openModal}
           onDismiss={() => setOpenModal(false)}
-          class={tw`container rounded bg-white p-5 h-5/6`}
+          class={tw`container rounded bg-white p-5 h-5/6 overflow-y-auto`}
         >
-          {JSON.stringify(componentSchemas)}
+          <div>
+            {components?.map(({ html, component, componentLabel }, index) => {
+              return (
+                <>
+                  <label>{componentLabel}</label>
+                  <div class="relative border rounded">
+                    <iframe
+                      srcDoc={`<!DOCTYPE html>${html}`}
+                      key={index}
+                      class={tw`h-[200px] max-h-[250px] w-full`}
+                    />
+                    <div
+                      class={tw`group flex items-center justify-center absolute inset-0 z-50 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors easy-in`}
+                      onClick={() => {
+                        onAddComponent(component);
+                        setOpenModal(false);
+                      }}
+                    >
+                      <PlusIcon
+                        width={32}
+                        height={32}
+                        class={tw`hidden group-hover:block text-gray-400`}
+                      />
+                    </div>
+                  </div>
+                </>
+              );
+            })}
+          </div>
         </Modal>
       )}
     </>

--- a/src/AddNewComponent.tsx
+++ b/src/AddNewComponent.tsx
@@ -4,6 +4,22 @@ import PlusIcon from "./icons/PlusIcon.tsx";
 import Button from "./ui/Button.tsx";
 import Modal from "./ui/Modal.tsx";
 import ComponentPreviewList from "./ComponentPreviewList.tsx";
+import type { ComponentPreview } from "../editor.tsx";
+
+type ToCState = { islands: ComponentPreview[]; components: ComponentPreview[] };
+
+function ToCItem({ component, componentLabel }: ComponentPreview) {
+  return (
+    <li key={component}>
+      <a
+        class={tw`font-medium  text-gray-500 hover:text-black`}
+        href={`#${component}`}
+      >
+        {componentLabel}
+      </a>
+    </li>
+  );
+}
 
 interface Props {
   onAddComponent: (componentName: string) => void;
@@ -11,6 +27,16 @@ interface Props {
 
 export default function AddNewComponent({ onAddComponent }: Props) {
   const [openModal, setOpenModal] = useState<boolean>(false);
+  const [tocComponents, setToCComponents] = useState<
+    ToCState
+  >({ islands: [], components: [] });
+  const registerToC = (newToC: Partial<ToCState>) => {
+    console.log("New ToC", newToC);
+    setToCComponents((oldToCComponents) => ({
+      ...oldToCComponents,
+      ...newToC,
+    }));
+  };
 
   return (
     <>
@@ -21,28 +47,43 @@ export default function AddNewComponent({ onAddComponent }: Props) {
         <PlusIcon />
       </Button>
 
-      {openModal && (
-        <Modal
-          open={openModal}
-          onDismiss={() => setOpenModal(false)}
-          class={tw`container rounded bg-white p-5 max-h-[83.33%] overflow-y-auto`}
-        >
-          <div>
-            <div class="w-full flex justify-between mb-4">
-              <span class={tw`text-xl font-bold`}>Componentes</span>
-              <Button onClick={() => setOpenModal(false)}>
-                <PlusIcon class={tw`rotate-45`} />
-              </Button>
-            </div>
+      <Modal
+        open={openModal}
+        onDismiss={() => setOpenModal(false)}
+        class={tw`container rounded bg-white p-5`}
+      >
+        <div class="w-full flex justify-between mb-4">
+          <span class={tw`text-xl font-bold`}>Componentes</span>
+          <Button onClick={() => setOpenModal(false)}>
+            <PlusIcon class={tw`rotate-45`} />
+          </Button>
+        </div>
+
+        <div class={tw`flex`}>
+          <div class={tw`overflow-y-auto max-h-[80vh] h-[80vh] w-full`}>
             <ComponentPreviewList
+              registerToC={registerToC}
               onClickComponent={(componentName) => {
                 onAddComponent(componentName);
                 setOpenModal(false);
               }}
             />
           </div>
-        </Modal>
-      )}
+          <nav
+            class={tw`ml-4 px-4 border-l w-1/6`}
+            aria-label="Table of components"
+          >
+            <ul>
+              {tocComponents.components.map((
+                props,
+              ) => <ToCItem key={props.component} {...props} />)}
+              {tocComponents.islands.map((
+                props,
+              ) => <ToCItem key={props.component} {...props} />)}
+            </ul>
+          </nav>
+        </div>
+      </Modal>
     </>
   );
 }

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -1,63 +1,111 @@
 import { tw } from "twind";
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { IS_BROWSER } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import type { ComponentPreview } from "../editor.tsx";
 
-let _components: ComponentPreview[] | undefined = undefined;
+let components: ComponentPreview[] | undefined = undefined;
+let islands: ComponentPreview[] | undefined = undefined;
+
+interface ComponentPreviewProps extends ComponentPreview {
+  onClick: () => void;
+}
+
+function ComponentPreview(
+  { componentLabel, link, onClick }: ComponentPreviewProps,
+) {
+  return (
+    <div class={tw`mb-3 last-child:mb-0`}>
+      <label class={tw`font-bold`}>{componentLabel}</label>
+      <div
+        class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
+      >
+        {link
+          ? (
+            <iframe
+              src={link}
+              class={tw`max-h-[250px] w-full`}
+            />
+          )
+          : null}
+        <div
+          class={tw`group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in`}
+          onClick={onClick}
+        >
+          <PlusIcon
+            width={32}
+            height={32}
+            class={tw`hidden group-hover:block text-gray-400`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
 
 interface Props {
   onClickComponent: (componentName: string) => void;
 }
 
 export default function ComponentPreviewList({ onClickComponent }: Props) {
-  const [components, setComponents] = useState<
-    ComponentPreview[] | undefined
-  >(_components);
+  const [_, update] = useState<boolean>(false);
 
   // Fetch components once
-  if (IS_BROWSER && !_components) {
-    // TODO: change this to GET
-    fetch("/live/api/components", { method: "POST" }).then((res) => res.json())
-      .then(({ components: apiComponents }) => {
-        _components = apiComponents;
-        setComponents(apiComponents);
-      });
-  }
+  useEffect(function fetchComponentAndIslands() {
+    let cancel = false;
+    if (IS_BROWSER && !components) {
+      // TODO: change this to GET
+      fetch("/live/api/components").then((res) => res.json())
+        .then(({ components: apiComponents }) => {
+          if (cancel) {
+            return;
+          }
+
+          components = apiComponents;
+          update((oldValue) => !oldValue);
+        });
+    }
+
+    if (IS_BROWSER && !islands) {
+      fetch("/live/api/components").then((res) => res.json())
+        .then(({ islands: apiIslands }) => {
+          if (cancel) {
+            return;
+          }
+
+          islands = apiIslands;
+          update((oldValue) => !oldValue);
+        });
+    }
+
+    return () => {
+      cancel = true;
+    };
+  }, []);
 
   return (
     <>
       {components?.map(
-        ({ html, component, componentLabel }, index) => {
+        (componentPreview) => {
           return (
-            <div class={tw`mb-3 last-child:mb-0`}>
-              <label class={tw`font-bold`}>{componentLabel}</label>
-              <div
-                class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
-              >
-                {html
-                  ? (
-                    <iframe
-                      srcDoc={`<!DOCTYPE html>${html}`}
-                      key={index}
-                      class={tw`max-h-[250px] w-full`}
-                    />
-                  )
-                  : null}
-                <div
-                  class={tw`group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in`}
-                  onClick={() => {
-                    onClickComponent(component);
-                  }}
-                >
-                  <PlusIcon
-                    width={32}
-                    height={32}
-                    class={tw`hidden group-hover:block text-gray-400`}
-                  />
-                </div>
-              </div>
-            </div>
+            <ComponentPreview
+              {...componentPreview}
+              onClick={() => {
+                onClickComponent(componentPreview.component);
+              }}
+            />
+          );
+        },
+      )}
+      {islands?.map(
+        (componentPreview) => {
+          return (
+            <ComponentPreview
+              {...componentPreview}
+              onClick={() => {
+                onClickComponent(componentPreview.component);
+              }}
+            />
           );
         },
       )}

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "preact/hooks";
-import { asset, IS_BROWSER } from "$fresh/runtime.ts";
+import { asset } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import type { ComponentPreview } from "../editor.tsx";
 
@@ -19,24 +19,22 @@ export default function ComponentPreviewList(
 
   useEffect(function fetchComponentAndIslands() {
     let cancel = false;
-    if (IS_BROWSER) {
-      const effect = async () => {
-        // Using asset to add the querystring __fresh_c=BUILD_ID
-        const { components: apiComponents, islands } = await fetch(
-          asset("/live/api/components"),
-        ).then((res) => res.json());
+    const effect = async () => {
+      // Using asset to add the querystring __fresh_c=BUILD_ID
+      const { components: apiComponents, islands } = await fetch(
+        asset("/live/api/components"),
+      ).then((res) => res.json());
 
-        if (cancel) return;
-        const newComponents = [
-          ...apiComponents,
-          ...islands,
-        ];
-        setComponents(newComponents);
-        registerToC(newComponents);
-      };
+      if (cancel) return;
+      const newComponents = [
+        ...apiComponents,
+        ...islands,
+      ];
+      setComponents(newComponents);
+      registerToC(newComponents);
+    };
 
-      effect();
-    }
+    effect();
 
     return () => {
       cancel = true;

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -1,0 +1,60 @@
+import { tw } from "twind";
+import { useState } from "preact/hooks";
+import { IS_BROWSER } from "$fresh/runtime.ts";
+import PlusIcon from "./icons/PlusIcon.tsx";
+import type { ComponentPreview } from "../editor.tsx";
+
+interface Props {
+  onClickComponent: (componentName: string) => void;
+}
+
+export default function ComponentPreviewList({ onClickComponent }: Props) {
+  const [components, setComponents] = useState<
+    ComponentPreview[] | undefined
+  >(undefined);
+
+  if (IS_BROWSER && !components) {
+    // TODO: change this to GET
+    fetch("/live/api/components", { method: "POST" }).then((res) => res.json())
+      .then(({ components: apiComponents }) => setComponents(apiComponents));
+  }
+
+  return (
+    <>
+      {components?.map(
+        ({ html, component, componentLabel }, index) => {
+          return (
+            <div class={tw`mb-3 last-child:mb-0`}>
+              <label class={tw`font-bold`}>{componentLabel}</label>
+              <div
+                class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
+              >
+                {html
+                  ? (
+                    <iframe
+                      srcDoc={`<!DOCTYPE html>${html}`}
+                      key={index}
+                      class={tw`max-h-[250px] w-full`}
+                    />
+                  )
+                  : null}
+                <div
+                  class={tw`group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in`}
+                  onClick={() => {
+                    onClickComponent(component);
+                  }}
+                >
+                  <PlusIcon
+                    width={32}
+                    height={32}
+                    class={tw`hidden group-hover:block text-gray-400`}
+                  />
+                </div>
+              </div>
+            </div>
+          );
+        },
+      )}
+    </>
+  );
+}

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -22,10 +22,9 @@ export default function ComponentPreviewList(
     let cancel = false;
     if (IS_BROWSER) {
       const effect = async () => {
-        const [{ components: apiComponents }, { islands }] = await Promise.all([
-          fetch("/live/api/components").then((res) => res.json()),
-          fetch("/live/api/islands").then((res) => res.json()),
-        ]);
+        const { components: apiComponents, islands } = await fetch(
+          "/live/api/components",
+        ).then((res) => res.json());
 
         if (cancel) return;
         const newComponents = [

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -1,6 +1,6 @@
 import { tw } from "twind";
 import { useEffect, useState } from "preact/hooks";
-import { IS_BROWSER } from "$fresh/runtime.ts";
+import { asset, IS_BROWSER } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import type { ComponentPreview } from "../editor.tsx";
 
@@ -22,8 +22,9 @@ export default function ComponentPreviewList(
     let cancel = false;
     if (IS_BROWSER) {
       const effect = async () => {
+        // Using asset to add the querystring __fresh_c=BUILD_ID
         const { components: apiComponents, islands } = await fetch(
-          "/live/api/components",
+          asset("/live/api/components"),
         ).then((res) => res.json());
 
         if (cancel) return;
@@ -57,7 +58,7 @@ export default function ComponentPreviewList(
                 class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
               >
                 <iframe
-                  data-src={link}
+                  data-src={asset(link)}
                   class={tw`max-h-[250px] w-full`}
                 />
                 <div

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -8,29 +8,25 @@ let components: ComponentPreview[] | undefined = undefined;
 let islands: ComponentPreview[] | undefined = undefined;
 
 interface ComponentPreviewProps extends ComponentPreview {
-  onClick: () => void;
+  onClickComponent: (componentName: string) => void;
 }
 
 function ComponentPreview(
-  { componentLabel, link, onClick }: ComponentPreviewProps,
+  { componentLabel, link, onClickComponent, component }: ComponentPreviewProps,
 ) {
   return (
-    <div class={tw`mb-3 last-child:mb-0`}>
-      <label class={tw`font-bold`}>{componentLabel}</label>
+    <div class={tw`mb-3 last-child:mb-0`} id={component}>
+      <label class={tw`font-medium`}>{componentLabel}</label>
       <div
         class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
       >
-        {link
-          ? (
-            <iframe
-              src={link}
-              class={tw`max-h-[250px] w-full`}
-            />
-          )
-          : null}
+        <iframe
+          src={link}
+          class={tw`max-h-[250px] w-full`}
+        />
         <div
           class={tw`group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in`}
-          onClick={onClick}
+          onClick={() => onClickComponent(component)}
         >
           <PlusIcon
             width={32}
@@ -45,16 +41,20 @@ function ComponentPreview(
 
 interface Props {
   onClickComponent: (componentName: string) => void;
+  registerToC: (
+    tocList: { islands?: ComponentPreview[]; components?: ComponentPreview[] },
+  ) => void;
 }
 
-export default function ComponentPreviewList({ onClickComponent }: Props) {
+export default function ComponentPreviewList(
+  { onClickComponent, registerToC }: Props,
+) {
   const [_, update] = useState<boolean>(false);
 
   // Fetch components once
   useEffect(function fetchComponentAndIslands() {
     let cancel = false;
     if (IS_BROWSER && !components) {
-      // TODO: change this to GET
       fetch("/live/api/components").then((res) => res.json())
         .then(({ components: apiComponents }) => {
           if (cancel) {
@@ -63,11 +63,12 @@ export default function ComponentPreviewList({ onClickComponent }: Props) {
 
           components = apiComponents;
           update((oldValue) => !oldValue);
+          registerToC({ components: apiComponents });
         });
     }
 
     if (IS_BROWSER && !islands) {
-      fetch("/live/api/components").then((res) => res.json())
+      fetch("/live/api/islands").then((res) => res.json())
         .then(({ islands: apiIslands }) => {
           if (cancel) {
             return;
@@ -75,6 +76,7 @@ export default function ComponentPreviewList({ onClickComponent }: Props) {
 
           islands = apiIslands;
           update((oldValue) => !oldValue);
+          registerToC({ islands: apiIslands });
         });
     }
 
@@ -90,9 +92,7 @@ export default function ComponentPreviewList({ onClickComponent }: Props) {
           return (
             <ComponentPreview
               {...componentPreview}
-              onClick={() => {
-                onClickComponent(componentPreview.component);
-              }}
+              onClickComponent={onClickComponent}
             />
           );
         },
@@ -102,9 +102,7 @@ export default function ComponentPreviewList({ onClickComponent }: Props) {
           return (
             <ComponentPreview
               {...componentPreview}
-              onClick={() => {
-                onClickComponent(componentPreview.component);
-              }}
+              onClickComponent={onClickComponent}
             />
           );
         },

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -55,7 +55,7 @@ export default function ComponentPreviewList(
               <label class="font-medium">{componentLabel}</label>
               <div class="relative border rounded min-h-[50px] max-h-[250px]">
                 <iframe
-                  data-src={asset(link)}
+                  src={asset(link)}
                   class="max-h-[250px] w-full"
                 />
                 <div

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -4,6 +4,8 @@ import { IS_BROWSER } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import type { ComponentPreview } from "../editor.tsx";
 
+let _components: ComponentPreview[] | undefined = undefined;
+
 interface Props {
   onClickComponent: (componentName: string) => void;
 }
@@ -11,12 +13,16 @@ interface Props {
 export default function ComponentPreviewList({ onClickComponent }: Props) {
   const [components, setComponents] = useState<
     ComponentPreview[] | undefined
-  >(undefined);
+  >(_components);
 
-  if (IS_BROWSER && !components) {
+  // Fetch components once
+  if (IS_BROWSER && !_components) {
     // TODO: change this to GET
     fetch("/live/api/components", { method: "POST" }).then((res) => res.json())
-      .then(({ components: apiComponents }) => setComponents(apiComponents));
+      .then(({ components: apiComponents }) => {
+        _components = apiComponents;
+        setComponents(apiComponents);
+      });
   }
 
   return (

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -4,8 +4,6 @@ import { IS_BROWSER } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
 import type { ComponentPreview } from "../editor.tsx";
 
-let components: ComponentPreview[] | undefined = undefined;
-
 interface Props {
   onClickComponent: (componentName: string) => void;
   registerToC: (
@@ -16,11 +14,13 @@ interface Props {
 export default function ComponentPreviewList(
   { onClickComponent, registerToC }: Props,
 ) {
-  const [_, update] = useState<boolean>(false);
+  const [components, setComponents] = useState<ComponentPreview[] | undefined>(
+    undefined,
+  );
 
   useEffect(function fetchComponentAndIslands() {
     let cancel = false;
-    if (IS_BROWSER && !components) {
+    if (IS_BROWSER) {
       const effect = async () => {
         const [{ components: apiComponents }, { islands }] = await Promise.all([
           fetch("/live/api/components").then((res) => res.json()),
@@ -28,13 +28,12 @@ export default function ComponentPreviewList(
         ]);
 
         if (cancel) return;
-
-        components = [
+        const newComponents = [
           ...apiComponents,
           ...islands,
         ];
-        update((old) => !old);
-        registerToC(components);
+        setComponents(newComponents);
+        registerToC(newComponents);
       };
 
       effect();
@@ -50,7 +49,10 @@ export default function ComponentPreviewList(
       {components?.map(
         ({ component, componentLabel, link }) => {
           return (
-            <div class={tw`mb-3 last-child:mb-0`} id={component}>
+            <div
+              id={component}
+              class={tw`mb-3 last-child:mb-0`}
+            >
               <label class={tw`font-medium`}>{componentLabel}</label>
               <div
                 class={tw`relative border rounded min-h-[50px] max-h-[250px]`}

--- a/src/ComponentPreviewList.tsx
+++ b/src/ComponentPreviewList.tsx
@@ -1,4 +1,3 @@
-import { tw } from "twind";
 import { useEffect, useState } from "preact/hooks";
 import { asset, IS_BROWSER } from "$fresh/runtime.ts";
 import PlusIcon from "./icons/PlusIcon.tsx";
@@ -51,24 +50,22 @@ export default function ComponentPreviewList(
           return (
             <div
               id={component}
-              class={tw`mb-3 last-child:mb-0`}
+              class="mb-3 last-child:mb-0"
             >
-              <label class={tw`font-medium`}>{componentLabel}</label>
-              <div
-                class={tw`relative border rounded min-h-[50px] max-h-[250px]`}
-              >
+              <label class="font-medium">{componentLabel}</label>
+              <div class="relative border rounded min-h-[50px] max-h-[250px]">
                 <iframe
                   data-src={asset(link)}
-                  class={tw`max-h-[250px] w-full`}
+                  class="max-h-[250px] w-full"
                 />
                 <div
-                  class={tw`group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in`}
+                  class="group flex items-center justify-center absolute inset-0 cursor-pointer hover:bg-gray-200 hover:bg-opacity-50 transition-colors ease-in"
                   onClick={() => onClickComponent(component)}
                 >
                   <PlusIcon
                     width={32}
                     height={32}
-                    class={tw`hidden group-hover:block text-gray-400`}
+                    class="hidden group-hover:block text-gray-400"
                   />
                 </div>
               </div>

--- a/src/Editor.tsx
+++ b/src/Editor.tsx
@@ -2,7 +2,7 @@ import type { PageComponentData, Schemas } from "../types.ts";
 import EditorProvider from "./EditorProvider.tsx";
 import EditorSidebar from "./EditorSidebar.tsx";
 
-interface Props {
+export interface Props {
   components: PageComponentData[];
   template: string;
   componentSchemas: Schemas;

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -1,44 +1,10 @@
 import { useRef } from "preact/hooks";
 import { useEditor } from "$live/src/EditorProvider.tsx";
-import { tw } from "twind";
 import Button from "./ui/Button.tsx";
 import JSONSchemaForm from "./ui/JSONSchemaForm.tsx";
 import { FormProvider, useForm } from "react-hook-form";
 import type { PageComponentData } from "../types.ts";
-
-function AddNewComponent({ onAddComponent }) {
-  const { componentSchemas } = useEditor();
-  const selectedComponent = useRef("");
-
-  return (
-    <div class="py-1 mb-2">
-      Selecione componente para adicionar
-      <div class="flex">
-        <select
-          class={tw`border hover:border-black py-1 px-2 mr-1 rounded transition-colors ease-in`}
-          value={"-1"}
-          onInput={(e) => {
-            selectedComponent.current = e.target.value;
-          }}
-        >
-          {Object.keys(componentSchemas).map((componentName) => (
-            <option value={componentName}>
-              {componentSchemas[componentName]?.title ?? componentName}
-            </option>
-          ))}
-        </select>
-        <Button
-          onClick={() => {
-            onAddComponent(selectedComponent.current);
-            selectedComponent.current = "";
-          }}
-        >
-          Adicionar
-        </Button>
-      </div>
-    </div>
-  );
-}
+import AddNewComponent from "./AddNewComponent.tsx";
 
 function mapComponentsToFormData(components: PageComponentData[]) {
   return components.reduce((curr, component, index) => {

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -1,9 +1,14 @@
 import { useEditor } from "$live/src/EditorProvider.tsx";
 import Button from "./ui/Button.tsx";
 import JSONSchemaForm from "./ui/JSONSchemaForm.tsx";
-import { FormProvider } from "react-hook-form";
+import { FormProvider as FP } from "react-hook-form";
+import type { FieldValues, UseFormReturn } from "react-hook-form";
 import AddNewComponent from "./AddNewComponent.tsx";
 import useEditorOperations from "./useEditorForm.tsx";
+
+const FormProvider = FP as <TFieldValues extends FieldValues, TContext = any>(
+  props: UseFormReturn<TFieldValues, TContext>,
+) => JSX.Element;
 
 const DEFAULT_SCHEMA = { title: "default", type: "object", properties: {} };
 

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "preact/hooks";
+import { useCallback, useRef } from "preact/hooks";
 import { useEditor } from "$live/src/EditorProvider.tsx";
 import Button from "./ui/Button.tsx";
 import JSONSchemaForm from "./ui/JSONSchemaForm.tsx";
@@ -98,11 +98,12 @@ export default function EditorSidebar() {
     remove(removedIndex);
   };
 
-  const handleAddComponent = (componentName: string) => {
-    components.push({ component: componentName });
+  const handleAddComponent = useCallback((componentName: string) => {
+    const _components = componentsRef.current;
+    _components.push({ component: componentName });
 
     append({});
-  };
+  }, [componentsRef]);
 
   return (
     <div class="bg-white min-h-screen w-3/12 border-l-2 p-2">

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -5,6 +5,8 @@ import { FormProvider } from "react-hook-form";
 import AddNewComponent from "./AddNewComponent.tsx";
 import useEditorOperations from "./useEditorForm.tsx";
 
+const DEFAULT_SCHEMA = { title: "default", type: "object", properties: {} };
+
 export default function EditorSidebar() {
   const { componentSchemas, template, components: initialComponents } =
     useEditor();
@@ -62,15 +64,14 @@ export default function EditorSidebar() {
                   removeComponents={handleRemoveComponent}
                   prefix={`components.${index}` as const}
                   index={index}
-                  schema={componentSchemas[component] ??
-                    { title: component, type: "object", properties: {} }}
+                  schema={componentSchemas[component] ?? DEFAULT_SCHEMA}
                 />
               );
             })}
           </form>
-
-          <AddNewComponent onAddComponent={handleAddComponent} />
         </FormProvider>
+
+        <AddNewComponent onAddComponent={handleAddComponent} />
       </div>
     </div>
   );

--- a/src/icons/PlusIcon.tsx
+++ b/src/icons/PlusIcon.tsx
@@ -1,0 +1,44 @@
+import type { h } from "preact";
+
+export default function PlusIcon(
+  { class: className, width = 16, height = 16 }: h.JSX.SVGAttributes<
+    SVGElement
+  >,
+) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={width}
+      height={height}
+      class={className}
+      fill="#000000"
+      viewBox="0 0 256 256"
+    >
+      <rect width="256" height="256" fill="none"></rect>
+      <line
+        x1="40"
+        y1="128"
+        x2="216"
+        y2="128"
+        fill="none"
+        stroke="#000000"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"
+      >
+      </line>
+      <line
+        x1="128"
+        y1="40"
+        x2="128"
+        y2="216"
+        fill="none"
+        stroke="#000000"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16"
+      >
+      </line>
+    </svg>
+  );
+}

--- a/src/icons/PlusIcon.tsx
+++ b/src/icons/PlusIcon.tsx
@@ -11,7 +11,7 @@ export default function PlusIcon(
       width={width}
       height={height}
       class={className}
-      fill="#000000"
+      fill="currentColor"
       viewBox="0 0 256 256"
     >
       <rect width="256" height="256" fill="none"></rect>
@@ -21,7 +21,7 @@ export default function PlusIcon(
         x2="216"
         y2="128"
         fill="none"
-        stroke="#000000"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="16"
@@ -33,7 +33,7 @@ export default function PlusIcon(
         x2="128"
         y2="216"
         fill="none"
-        stroke="#000000"
+        stroke="currentColor"
         stroke-linecap="round"
         stroke-linejoin="round"
         stroke-width="16"

--- a/src/ui/Button.tsx
+++ b/src/ui/Button.tsx
@@ -1,5 +1,4 @@
 import type { h } from "preact";
-import { tw } from "twind";
 
 export default function Button(
   props: h.JSX.HTMLAttributes<HTMLButtonElement>,
@@ -8,7 +7,7 @@ export default function Button(
     <button
       type="button"
       {...props}
-      class={tw`border py-1 px-2 rounded transition-colors ease-in ${
+      class={`border py-1 px-2 rounded transition-colors ease-in ${
         props.disabled
           ? "text-gray-400"
           : "hover:border-black hover:bg-gray-100"

--- a/src/ui/JSONSchemaForm.tsx
+++ b/src/ui/JSONSchemaForm.tsx
@@ -1,5 +1,6 @@
 import type {
   JSONSchema7,
+  JSONSchema7Definition,
   JSONSchema7TypeName,
 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts";
 import type { FunctionComponent, h } from "preact";
@@ -12,7 +13,7 @@ import TrashIcon from "../icons/TrashIcon.tsx";
 const FieldTypes: Record<
   Exclude<
     JSONSchema7TypeName,
-    "object" | "integer" | "array" | "null"
+    "object" | "array" | "null"
   >,
   FunctionComponent
 > = {
@@ -24,6 +25,17 @@ const FieldTypes: Record<
     />
   )),
   "number": forwardRef((props: h.JSX.HTMLAttributes<HTMLInputElement>, ref) => (
+    <input
+      {...props}
+      type="number"
+      ref={ref}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+    />
+  )),
+  "integer": forwardRef((
+    props: h.JSX.HTMLAttributes<HTMLInputElement>,
+    ref,
+  ) => (
     <input
       {...props}
       type="number"
@@ -60,8 +72,12 @@ function RenderFields(
   return (
     <>
       {properties.map(([field, property]) => {
-        const { type, title, properties: nestedProperties } = property;
-        if (Array.isArray(type) || type === undefined) {
+        const { type, title, properties: nestedProperties } =
+          property as JSONSchema7;
+        if (
+          Array.isArray(type) || type === undefined || type === "null" ||
+          type === "array"
+        ) {
           console.log("Type must be a string");
           return null;
         }
@@ -95,8 +111,8 @@ function RenderFields(
 
 interface Props {
   schema: JSONSchema7;
-  index?: number;
-  prefix?: string;
+  index: number;
+  prefix: string;
   changeOrder: (dir: "prev" | "next", pos: number) => void;
   removeComponents: (removedComponents: number) => void;
 }
@@ -113,32 +129,29 @@ export default function JSONSchemaForm(
       <div class="flex justify-between items-center">
         <legend class="font-bold">{schema.title}</legend>
 
-        {index !== undefined &&
-          (
-            <div class="flex gap-2">
-              <Button
-                onClick={() => {
-                  changeOrder("next", index);
-                }}
-              >
-                <CaretDownIcon />
-              </Button>
-              <Button
-                onClick={() => {
-                  changeOrder("prev", index);
-                }}
-              >
-                <CaretDownIcon class="rotate-180" />
-              </Button>
-              <Button
-                onClick={() => {
-                  removeComponents(index);
-                }}
-              >
-                <TrashIcon />
-              </Button>
-            </div>
-          )}
+        <div class="flex gap-2">
+          <Button
+            onClick={() => {
+              changeOrder("next", index);
+            }}
+          >
+            <CaretDownIcon />
+          </Button>
+          <Button
+            onClick={() => {
+              changeOrder("prev", index);
+            }}
+          >
+            <CaretDownIcon class="rotate-180" />
+          </Button>
+          <Button
+            onClick={() => {
+              removeComponents(index);
+            }}
+          >
+            <TrashIcon />
+          </Button>
+        </div>
       </div>
       <RenderFields
         properties={schema.properties}

--- a/src/ui/JSONSchemaForm.tsx
+++ b/src/ui/JSONSchemaForm.tsx
@@ -2,7 +2,7 @@ import type {
   JSONSchema7,
   JSONSchema7TypeName,
 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts";
-import type { FunctionComponent } from "preact";
+import type { FunctionComponent, h } from "preact";
 import { tw } from "twind";
 import { useFormContext } from "react-hook-form";
 import { forwardRef } from "preact/compat";
@@ -85,13 +85,7 @@ function RenderFields(
               {title}
             </label>
             <Field
-              {...register(fullPathField, {
-                value: property.default,
-                minLength: property.minLength,
-                maxLength: property.maxLength,
-                min: property.minimum,
-                max: property.maximum,
-              })}
+              {...register(fullPathField)}
             />
           </div>
         );
@@ -103,12 +97,13 @@ function RenderFields(
 interface Props {
   schema: JSONSchema7;
   index?: number;
+  prefix?: string;
   changeOrder: (dir: "prev" | "next", pos: number) => void;
   removeComponents: (removedComponents: number) => void;
 }
 
 export default function JSONSchemaForm(
-  { schema, index, changeOrder, removeComponents }: Props,
+  { schema, index, changeOrder, removeComponents, prefix }: Props,
 ) {
   if (schema.type !== "object") {
     throw new Error("Schema must be type object");
@@ -150,7 +145,7 @@ export default function JSONSchemaForm(
       </div>
       <RenderFields
         properties={schema.properties}
-        prefix={index !== undefined ? `${index}.` : ""}
+        prefix={prefix !== undefined ? `${prefix}.` : ""}
       />
     </div>
   );

--- a/src/ui/JSONSchemaForm.tsx
+++ b/src/ui/JSONSchemaForm.tsx
@@ -3,7 +3,6 @@ import type {
   JSONSchema7TypeName,
 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts";
 import type { FunctionComponent, h } from "preact";
-import { tw } from "twind";
 import { useFormContext } from "react-hook-form";
 import { forwardRef } from "preact/compat";
 import Button from "./Button.tsx";
@@ -21,7 +20,7 @@ const FieldTypes: Record<
     <input
       {...props}
       ref={ref}
-      class={tw`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
     />
   )),
   "number": forwardRef((props: h.JSX.HTMLAttributes<HTMLInputElement>, ref) => (
@@ -29,7 +28,7 @@ const FieldTypes: Record<
       {...props}
       type="number"
       ref={ref}
-      class={tw`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
     />
   )),
   "boolean": forwardRef((
@@ -40,7 +39,7 @@ const FieldTypes: Record<
       {...props}
       type="checkbox"
       ref={ref}
-      class={tw`border hover:border-black transition-colors ease-in rounded p-1 ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 ${props.class}`}
     />
   )),
 };
@@ -110,11 +109,9 @@ export default function JSONSchemaForm(
   }
 
   return (
-    <div class={tw`rounded-md border mb-2 p-2`}>
-      <div
-        class={tw`flex justify-between items-center`}
-      >
-        <legend class={tw`font-bold`}>{schema.title}</legend>
+    <div class="rounded-md border mb-2 p-2">
+      <div class="flex justify-between items-center">
+        <legend class="font-bold">{schema.title}</legend>
 
         {index !== undefined &&
           (

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -80,7 +80,9 @@ export default function Modal(
         onKeyDown={handleBackdropKeyDown}
         onClick={handleBackdropClick}
       >
-        <ModalContent {...props}>{children}</ModalContent>
+        <ModalContent {...props} onClick={(e) => e.stopPropagation()}>
+          {children}
+        </ModalContent>
       </div>,
       document.body,
     )

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -1,0 +1,91 @@
+import type { h } from "preact";
+import { useRef } from "preact/hooks";
+import { createPortal } from "preact/compat";
+import useTrapFocus from "./hooks/useTrapFocus.tsx";
+import { tw } from "twind";
+
+interface ModalContentProps extends h.JSX.HTMLAttributes<HTMLDivElement> {}
+
+function ModalContent({ children, ...props }: ModalContentProps) {
+  const trapFocusRef = useRef<HTMLDivElement>(null);
+  const beforeElementRef = useRef<HTMLDivElement>(null);
+  const afterElementRef = useRef<HTMLDivElement>(null);
+
+  useTrapFocus({
+    trapFocusRef,
+    beforeElementRef,
+    afterElementRef,
+  });
+
+  return (
+    <>
+      <div
+        ref={beforeElementRef}
+        tabIndex={0}
+        aria-hidden="true"
+      />
+      <div
+        ref={trapFocusRef}
+        aria-modal="true"
+        role="dialog"
+        tabIndex={-1}
+        {...props}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+      >
+        {children}
+      </div>
+      <div
+        ref={afterElementRef}
+        tabIndex={0}
+        aria-hidden="true"
+      />
+    </>
+  );
+}
+
+interface Props extends ModalContentProps {
+  open: boolean;
+  onDismiss?: (event: MouseEvent | KeyboardEvent) => void;
+  modalProps?: Omit<
+    h.JSX.HTMLAttributes<HTMLDivElement>,
+    "onClick" | "onKeyDown"
+  >;
+}
+
+export default function Modal(
+  { children, open, modalProps = {}, onDismiss, ...props }: Props,
+) {
+  const handleBackdropClick = (event: MouseEvent) => {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    event.stopPropagation();
+    onDismiss?.(event);
+  };
+
+  const handleBackdropKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" || event.defaultPrevented) {
+      return;
+    }
+
+    event.stopPropagation();
+    onDismiss?.(event);
+  };
+
+  return open
+    ? createPortal(
+      <div
+        {...modalProps}
+        class={tw`bg-gray-500 bg-opacity-50 ${modalProps?.class}`}
+        onKeyDown={handleBackdropKeyDown}
+        onClick={handleBackdropClick}
+      >
+        <ModalContent {...props}>{children}</ModalContent>
+      </div>,
+      document.body,
+    )
+    : null;
+}

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -30,9 +30,6 @@ function ModalContent({ children, ...props }: ModalContentProps) {
         role="dialog"
         tabIndex={-1}
         {...props}
-        onClick={(e) => {
-          e.stopPropagation();
-        }}
       >
         {children}
       </div>
@@ -79,7 +76,7 @@ export default function Modal(
     ? createPortal(
       <div
         {...modalProps}
-        class={tw`bg-gray-500 bg-opacity-50 ${modalProps?.class}`}
+        class={tw`bg-gray-500 bg-opacity-50 fixed inset-0 z-50 flex justify-center items-center ${modalProps?.class}`}
         onKeyDown={handleBackdropKeyDown}
         onClick={handleBackdropClick}
       >

--- a/src/ui/Modal.tsx
+++ b/src/ui/Modal.tsx
@@ -2,7 +2,6 @@ import type { h } from "preact";
 import { useRef } from "preact/hooks";
 import { createPortal } from "preact/compat";
 import useTrapFocus from "./hooks/useTrapFocus.tsx";
-import { tw } from "twind";
 
 interface ModalContentProps extends h.JSX.HTMLAttributes<HTMLDivElement> {}
 
@@ -76,7 +75,7 @@ export default function Modal(
     ? createPortal(
       <div
         {...modalProps}
-        class={tw`bg-gray-500 bg-opacity-50 fixed inset-0 z-50 flex justify-center items-center ${modalProps?.class}`}
+        class={`bg-gray-500 bg-opacity-50 fixed inset-0 z-50 flex justify-center items-center ${modalProps?.class}`}
         onKeyDown={handleBackdropKeyDown}
         onClick={handleBackdropClick}
       >

--- a/src/ui/hooks/useTrapFocus.tsx
+++ b/src/ui/hooks/useTrapFocus.tsx
@@ -1,0 +1,115 @@
+import { tabbable } from "tabbable";
+import { useEffect, useRef } from "preact/hooks";
+import type { RefObject } from "preact";
+
+// Type from tabbable
+// https://github.com/focus-trap/tabbable/blob/a09ba0be3d680e54aef5e32449b8fb033780780b/index.d.ts#L1
+type FocusableElement = HTMLElement | SVGElement;
+
+interface TrapFocusParams {
+  beforeElementRef: RefObject<HTMLElement>;
+  trapFocusRef: RefObject<HTMLElement>;
+  afterElementRef: RefObject<HTMLElement>;
+}
+
+/*
+ * Element that will maintain the focus inside trapFocusRef, focus the first element,
+ * and focus back on the element that was in focus when useTrapFocus was triggered.
+ *
+ * Inspired by Reakit useTrapFocus https://github.com/reakit/reakit/blob/a211d94da9f3b683182568a56479b91afb1b85ae/packages/reakit/src/Dialog/__utils/useFocusTrap.ts
+ */
+const useTrapFocus = ({
+  trapFocusRef,
+  beforeElementRef,
+  afterElementRef,
+}: TrapFocusParams) => {
+  const tabbableNodesRef = useRef<FocusableElement[]>();
+  const nodeToRestoreRef = useRef<HTMLElement | null>(
+    window.document?.hasFocus()
+      ? (document.activeElement as HTMLElement)
+      : null,
+  );
+
+  // Focus back on the element that was focused when useTrapFocus is triggered.
+  useEffect(() => {
+    const nodeToRestore = nodeToRestoreRef.current;
+
+    return () => {
+      nodeToRestore?.focus();
+    };
+  }, [nodeToRestoreRef]);
+
+  // Set focus on first tabbable element
+  useEffect(() => {
+    if (!trapFocusRef.current) {
+      return;
+    }
+
+    if (!tabbableNodesRef.current) {
+      tabbableNodesRef.current = tabbable(trapFocusRef.current);
+    }
+
+    const [firstTabbable] = tabbableNodesRef.current;
+
+    if (!firstTabbable) {
+      trapFocusRef.current.focus();
+
+      return;
+    }
+
+    firstTabbable.focus();
+  }, [trapFocusRef]);
+
+  // Handle loop focus. Set keydown and focusin event listeners
+  useEffect(() => {
+    if (
+      !trapFocusRef.current ||
+      !beforeElementRef.current ||
+      !afterElementRef.current
+    ) {
+      return;
+    }
+
+    const beforeElement = beforeElementRef.current;
+    const afterElement = afterElementRef.current;
+    const trapFocus = trapFocusRef.current;
+
+    const handleLoopFocus = (nativeEvent: FocusEvent) => {
+      if (!document.hasFocus()) {
+        return;
+      }
+
+      tabbableNodesRef.current = tabbable(trapFocusRef.current!);
+
+      if (!tabbableNodesRef.current.length) {
+        trapFocus.focus();
+      }
+
+      /*
+       * Handle loop focus from beforeElementRef. This node can only be focused if the user press shift tab.
+       * It will focus the last element of the trapFocusRef.
+       */
+      if (nativeEvent.target === beforeElement) {
+        tabbableNodesRef.current[tabbableNodesRef.current.length - 1]?.focus();
+      }
+
+      /*
+       * Handle loop focus from afterElementRef. This node can only be focused if the user press tab.
+       * It will focus the first element of the trapFocusRef.
+       */
+      if (nativeEvent.target === afterElement) {
+        tabbableNodesRef.current[0]?.focus();
+      }
+    };
+
+    beforeElement?.addEventListener("focusin", handleLoopFocus);
+    afterElement?.addEventListener("focusin", handleLoopFocus);
+
+    return () => {
+      beforeElement?.removeEventListener("focusin", handleLoopFocus);
+      afterElement?.removeEventListener("focusin", handleLoopFocus);
+    };
+  }, [tabbableNodesRef, afterElementRef, beforeElementRef, trapFocusRef]);
+};
+
+export default useTrapFocus;

--- a/src/useEditorForm.tsx
+++ b/src/useEditorForm.tsx
@@ -1,0 +1,117 @@
+import { useCallback, useRef } from "preact/hooks";
+import { useFieldArray, useForm } from "react-hook-form";
+import { PageComponentData } from "../types.ts";
+
+const COMPONENTS_KEY_NAME: "components" = "components" as const;
+
+type ComponentProp = Record<string, any>;
+type FormValues = {
+  [COMPONENTS_KEY_NAME]: ComponentProp[];
+};
+
+function mapComponentsToFormData(
+  components: PageComponentData[],
+): ComponentProp[] {
+  return components.map((component) => {
+    return component.props || {};
+  });
+}
+
+function mapFormDataToComponents(
+  formData: ComponentProp[],
+  currentComponents: PageComponentData[],
+) {
+  const components: PageComponentData[] = [];
+  currentComponents.forEach(({ component }, index) => {
+    const props = formData[index];
+
+    components.push({
+      component,
+      // Required check this, because the form doesn't handle undefined values
+      props: Object.keys(props).length === 0 ? undefined : props,
+    });
+  });
+
+  return components;
+}
+
+export default function useEditorOperations(
+  { components: initialComponents, template }: {
+    components: PageComponentData[];
+    template: string;
+  },
+) {
+  const methods = useForm<FormValues>({
+    defaultValues: {
+      [COMPONENTS_KEY_NAME]: mapComponentsToFormData(initialComponents),
+    },
+  });
+  const { fields, swap, remove, append } = useFieldArray({
+    control: methods.control,
+    name: COMPONENTS_KEY_NAME,
+  });
+
+  const componentsRef = useRef(initialComponents);
+  const components = componentsRef.current;
+
+  const reloadPage = () => document.location.reload();
+  const saveProps = async () => {
+    const components = mapFormDataToComponents(
+      methods.getValues(COMPONENTS_KEY_NAME),
+      componentsRef.current,
+    );
+
+    await fetch("/live/api/editor", {
+      method: "POST",
+      redirect: "manual",
+      body: JSON.stringify({ components, template }),
+    });
+    reloadPage();
+  };
+
+  const handleChangeOrder = (dir: "prev" | "next", pos: number) => {
+    let newPos: number;
+
+    if (dir === "prev") {
+      newPos = pos - 1;
+    } else {
+      newPos = pos + 1;
+    }
+
+    if (newPos < 0 || newPos >= components.length) {
+      return;
+    }
+
+    const prevComp = components[newPos];
+    components[newPos] = components[pos];
+    components[pos] = prevComp;
+
+    swap(pos, newPos);
+  };
+
+  const handleRemoveComponent = (removedIndex: number) => {
+    componentsRef.current = componentsRef.current.filter((_, index) =>
+      index !== removedIndex
+    );
+
+    remove(removedIndex);
+  };
+
+  const handleAddComponent = useCallback((componentName: string) => {
+    const _components = componentsRef.current;
+    _components.push({ component: componentName });
+
+    append({});
+  }, [componentsRef]);
+
+  return {
+    reloadPage,
+    saveProps,
+    handleAddComponent,
+    handleRemoveComponent,
+    handleChangeOrder,
+    componentsRef,
+    methods,
+    fields,
+  };
+}

--- a/types.ts
+++ b/types.ts
@@ -2,7 +2,7 @@ import { IslandModule, Plugin } from "$fresh/src/server/types.ts";
 import { Manifest } from "$fresh/server.ts";
 import { JSONSchema7 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts";
 
-export type Schema = JSONSchema7 | null;
+export type Schema = JSONSchema7;
 export type Schemas = Record<string, Schema>;
 
 export interface Module extends IslandModule {

--- a/types.ts
+++ b/types.ts
@@ -5,8 +5,13 @@ import { JSONSchema7 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9y
 export type Schema = JSONSchema7 | null;
 export type Schemas = Record<string, Schema>;
 
+export interface Module extends IslandModule {
+  schema?: JSONSchema7;
+}
+
 export interface DecoManifest extends Manifest {
-  components?: Record<string, IslandModule>;
+  islands: Record<string, Module>;
+  components: Record<string, Module>;
   schemas: Schemas;
 }
 

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -1,3 +1,5 @@
+import type { DecoManifest, Module } from "../types.ts";
+
 // Valid expressions: https://regex101.com/r/YCTBSM/2
 // /Component.tsx
 export const COMPONENT_NAME_REGEX = /^\/(\w*)\.(tsx|jsx|js|ts)/;
@@ -13,4 +15,12 @@ export function componentNameFromPath(componentPath: string) {
 
 export function isValidIsland(componentPath: string) {
   return !BLOCKED_ISLANDS_SCHEMAS.has(componentPath);
+}
+
+export function getComponentModule(
+  manifest: DecoManifest,
+  filename: string,
+): Module | undefined {
+  return manifest.islands?.[`./islands/${filename}.tsx`] ??
+    manifest.components?.[`./components/${filename}.tsx`];
 }

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -1,0 +1,16 @@
+// Valid expressions: https://regex101.com/r/YCTBSM/2
+// /Component.tsx
+export const COMPONENT_NAME_REGEX = /^\/(\w*)\.(tsx|jsx|js|ts)/;
+
+export const BLOCKED_ISLANDS_SCHEMAS = new Set([
+  "/Editor.tsx",
+  "/InspectVSCode.tsx",
+]);
+
+export function componentNameFromPath(componentPath: string) {
+  return componentPath.replace(COMPONENT_NAME_REGEX, "$1");
+}
+
+export function isValidIsland(componentPath: string) {
+  return !BLOCKED_ISLANDS_SCHEMAS.has(componentPath);
+}

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -2,15 +2,20 @@ import type { DecoManifest, Module } from "../types.ts";
 
 // Valid expressions: https://regex101.com/r/YCTBSM/2
 // /Component.tsx
-export const COMPONENT_NAME_REGEX = /^\/(\w*)\.(tsx|jsx|js|ts)/;
+// ./islands/Component.tsx
+// ./components/Component.tsx
+export const COMPONENT_NAME_REGEX =
+  /^(\.\/islands|\.\/components)?\/(\w*)\.(tsx|jsx|js|ts)/;
 
 export const BLOCKED_ISLANDS_SCHEMAS = new Set([
   "/Editor.tsx",
   "/InspectVSCode.tsx",
+  "./islands/Editor.tsx",
+  "./islands/InspectVSCode.tsx",
 ]);
 
 export function componentNameFromPath(componentPath: string) {
-  return componentPath.replace(COMPONENT_NAME_REGEX, "$1");
+  return componentPath.replace(COMPONENT_NAME_REGEX, "$2");
 }
 
 export function isValidIsland(componentPath: string) {

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -1,11 +1,13 @@
 import type { DecoManifest, Module } from "../types.ts";
 
-// Valid expressions: https://regex101.com/r/YCTBSM/2
+// Valid expressions: https://regex101.com/r/7sPtnb/1
 // /Component.tsx
-// ./islands/Component.tsx
-// ./components/Component.tsx
+// ./components/Foo.tsx
+// /islands/Foo.tsx
+// ./islands/Foo.tsx
+// ./components/deep/Test.tsx
 export const COMPONENT_NAME_REGEX =
-  /^(\.\/islands|\.\/components)?\/(\w*)\.(tsx|jsx|js|ts)/;
+  /^(\.?\/islands|\.?\/components)?\/([\w\/]*)\.(tsx|jsx|js|ts)/;
 
 export const BLOCKED_ISLANDS_SCHEMAS = new Set([
   "/Editor.tsx",


### PR DESCRIPTION
### Context
The Live Editor, already has a way to add components, but the user doesn't have enough information about the component, because he/she only sees the component label. It would be good to have a component preview to improve the UX.

### Solution
To achieve this new UX, this PR adds a Component List Modal, that renders all components and islands from a project inside a modal. 

#### Features added:
- [x] Component Preview Modal
- [x] Route `/live/api/[components]` return a list of component preview info (islands and components) for components/islands that export const schema. This route is one year cached, and immutable if contains __fresh_c=<ID>
 The shape of the response:

```ts
interface ComponentPreview {
  link: string;
  component: string; // Relative path to components/islands
  componentLabel: string; // schema.title or component relative path.
}

interface Output { islands: ComponentPreview[], components: ComponentPreview[] }
```

- [x] Route `/live/api/[components]/<component-name>` to render components. This route is one year cached, and immutable if contains __fresh_c=<ID>

#### Changes:
- [x] LivePage handles children
- [x] Manifest schema has schemas from components that export the schema, otherwise, the component can't be there
- [x] Refactor manifest and liveOptions to LiveContext class, singleton

#### Breaking Changes
> ⚠️ The project that uses this version needs to add `"tabbable": "https://esm.sh/v91/tabbable@5.3.3/",` entry to its import_map.json