### PR TITLE
feat: Improve Form fields to handle JSON Schema format

### DIFF
--- a/editor.tsx
+++ b/editor.tsx
@@ -9,7 +9,6 @@ import {
   getComponentModule,
 } from "./utils/component.ts";
 import { createServerTiming } from "./utils/serverTimings.ts";
-import { h } from "preact";
 
 const ONE_YEAR_CACHE = "public, max-age=31536000, immutable";
 

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -17,7 +17,7 @@ export default function EditorSidebar() {
     useEditor();
 
   const {
-    reloadPage,
+    onReset,
     onSubmit,
     handleAddComponent,
     handleRemoveComponent,
@@ -43,7 +43,7 @@ export default function EditorSidebar() {
             <div class="flex gap-2">
               <Button
                 type="button"
-                onClick={reloadPage}
+                onClick={onReset}
                 disabled={!methods.formState.isDirty}
               >
                 Descartar

--- a/src/EditorSidebar.tsx
+++ b/src/EditorSidebar.tsx
@@ -18,7 +18,7 @@ export default function EditorSidebar() {
 
   const {
     reloadPage,
-    saveProps,
+    onSubmit,
     handleAddComponent,
     handleRemoveComponent,
     handleChangeOrder,
@@ -34,32 +34,29 @@ export default function EditorSidebar() {
 
   return (
     <div class="bg-white min-h-screen w-3/12 border-l-2 p-2">
-      <header class="flex justify-between items-center">
-        <h2 class="font-bold text-lg">Editor</h2>
-        <div class="flex gap-2">
-          <Button
-            type="button"
-            onClick={reloadPage}
-            disabled={!methods.formState.isDirty}
-          >
-            Descartar
-          </Button>
-          <Button
-            type="button"
-            onClick={saveProps}
-            disabled={!methods.formState.isDirty}
-          >
-            Salvar
-          </Button>
-        </div>
-      </header>
-      <div class="mt-4">
-        <FormProvider {...methods}>
-          <form
-            onSubmit={(e) => {
-              e.preventDefault();
-            }}
-          >
+      <FormProvider {...methods}>
+        <form
+          onSubmit={onSubmit}
+        >
+          <header class="flex justify-between items-center">
+            <h2 class="font-bold text-lg">Editor</h2>
+            <div class="flex gap-2">
+              <Button
+                type="button"
+                onClick={reloadPage}
+                disabled={!methods.formState.isDirty}
+              >
+                Descartar
+              </Button>
+              <Button
+                type="submit"
+                disabled={!methods.formState.isDirty}
+              >
+                Salvar
+              </Button>
+            </div>
+          </header>
+          <div class="mt-4">
             {fields.map((field, index) => {
               const { component } = components[index];
               return (
@@ -73,11 +70,10 @@ export default function EditorSidebar() {
                 />
               );
             })}
-          </form>
-        </FormProvider>
-
-        <AddNewComponent onAddComponent={handleAddComponent} />
-      </div>
+          </div>
+        </form>
+      </FormProvider>
+      <AddNewComponent onAddComponent={handleAddComponent} />
     </div>
   );
 }

--- a/src/ui/JSONSchemaForm.tsx
+++ b/src/ui/JSONSchemaForm.tsx
@@ -1,6 +1,5 @@
 import type {
   JSONSchema7,
-  JSONSchema7Definition,
   JSONSchema7TypeName,
 } from "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts";
 import type { FunctionComponent, h } from "preact";
@@ -10,18 +9,31 @@ import Button from "./Button.tsx";
 import CaretDownIcon from "../icons/CaretDownIcon.tsx";
 import TrashIcon from "../icons/TrashIcon.tsx";
 
+const getInputTypeFromFormat = (format: JSONSchema7["format"]) => {
+  switch (format) {
+    case "uri":
+      return "url";
+    case "email":
+      return "email";
+    default:
+      return "";
+  }
+};
+
 const FieldTypes: Record<
   Exclude<
     JSONSchema7TypeName,
     "object" | "array" | "null"
   >,
-  FunctionComponent
+  FunctionComponent<h.JSX.HTMLAttributes<HTMLInputElement>>
 > = {
   "string": forwardRef((props: h.JSX.HTMLAttributes<HTMLInputElement>, ref) => (
     <input
       {...props}
       ref={ref}
-      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${
+        props.class ?? ""
+      }`}
     />
   )),
   "number": forwardRef((props: h.JSX.HTMLAttributes<HTMLInputElement>, ref) => (
@@ -29,7 +41,9 @@ const FieldTypes: Record<
       {...props}
       type="number"
       ref={ref}
-      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${
+        props.class ?? ""
+      }`}
     />
   )),
   "integer": forwardRef((
@@ -40,7 +54,9 @@ const FieldTypes: Record<
       {...props}
       type="number"
       ref={ref}
-      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 w-full ${
+        props.class ?? ""
+      }`}
     />
   )),
   "boolean": forwardRef((
@@ -51,18 +67,20 @@ const FieldTypes: Record<
       {...props}
       type="checkbox"
       ref={ref}
-      class={`border hover:border-black transition-colors ease-in rounded p-1 ${props.class}`}
+      class={`border hover:border-black transition-colors ease-in rounded p-1 ${
+        props.class ?? ""
+      }`}
     />
   )),
 };
 
-interface RenderFieldProps {
-  properties: JSONSchema7["properties"];
+interface RenderFieldProps
+  extends Pick<JSONSchema7, "required" | "properties"> {
   prefix: string;
 }
 
 function RenderFields(
-  { properties: jsonSchemaProperties, prefix }: RenderFieldProps,
+  { properties: jsonSchemaProperties, prefix, required = [] }: RenderFieldProps,
 ) {
   const { register } = useFormContext();
 
@@ -72,8 +90,14 @@ function RenderFields(
   return (
     <>
       {properties.map(([field, property]) => {
-        const { type, title, properties: nestedProperties } =
-          property as JSONSchema7;
+        const {
+          type,
+          title,
+          minLength,
+          maxLength,
+          pattern,
+          format,
+        } = property as JSONSchema7;
         if (
           Array.isArray(type) || type === undefined || type === "null" ||
           type === "array"
@@ -83,8 +107,11 @@ function RenderFields(
         }
 
         if (type === "object") {
+          const { properties: nestedProperties, required: nestedRequired } =
+            property as JSONSchema7;
           return (
             <RenderFields
+              required={nestedRequired}
               properties={nestedProperties}
               prefix={`${prefix}${field}.`}
             />
@@ -93,6 +120,8 @@ function RenderFields(
 
         const fullPathField = `${prefix}${field}`;
         const Field = FieldTypes[type];
+        const inputType = getInputTypeFromFormat(format);
+        const isFieldRequired = required.includes(field);
 
         return (
           <div class="flex flex-col items-start">
@@ -100,7 +129,15 @@ function RenderFields(
               {title}
             </label>
             <Field
-              {...register(fullPathField)}
+              type={inputType}
+              pattern={pattern}
+              required={isFieldRequired}
+              {...register(fullPathField, {
+                minLength,
+                maxLength,
+                pattern: pattern ? new RegExp(pattern) : undefined,
+                required: isFieldRequired,
+              })}
             />
           </div>
         );
@@ -154,6 +191,7 @@ export default function JSONSchemaForm(
         </div>
       </div>
       <RenderFields
+        required={schema.required}
         properties={schema.properties}
         prefix={prefix !== undefined ? `${prefix}.` : ""}
       />

--- a/src/ui/JSONSchemaForm.tsx
+++ b/src/ui/JSONSchemaForm.tsx
@@ -11,10 +11,17 @@ import TrashIcon from "../icons/TrashIcon.tsx";
 
 const getInputTypeFromFormat = (format: JSONSchema7["format"]) => {
   switch (format) {
-    case "uri":
-      return "url";
+    case "date":
+      return "date";
+    case "date-time":
+      return "datetime-local";
     case "email":
       return "email";
+    case "iri":
+    case "uri":
+      return "url";
+    case "time":
+      return "time";
     default:
       return "";
   }

--- a/src/useEditorForm.tsx
+++ b/src/useEditorForm.tsx
@@ -55,19 +55,21 @@ export default function useEditorOperations(
   const components = componentsRef.current;
 
   const reloadPage = () => document.location.reload();
-  const saveProps = async () => {
-    const components = mapFormDataToComponents(
-      methods.getValues(COMPONENTS_KEY_NAME),
-      componentsRef.current,
-    );
+  const onSubmit = methods.handleSubmit(
+    async ({ components: formComponents }) => {
+      const components = mapFormDataToComponents(
+        formComponents,
+        componentsRef.current,
+      );
 
-    await fetch("/live/api/editor", {
-      method: "POST",
-      redirect: "manual",
-      body: JSON.stringify({ components, template }),
-    });
-    reloadPage();
-  };
+      await fetch("/live/api/editor", {
+        method: "POST",
+        redirect: "manual",
+        body: JSON.stringify({ components, template }),
+      });
+      reloadPage();
+    },
+  );
 
   const handleChangeOrder = (dir: "prev" | "next", pos: number) => {
     let newPos: number;
@@ -106,7 +108,7 @@ export default function useEditorOperations(
 
   return {
     reloadPage,
-    saveProps,
+    onSubmit,
     handleAddComponent,
     handleRemoveComponent,
     handleChangeOrder,


### PR DESCRIPTION
### Context
To be more compatible with the JSON Schema the RenderField component should handle the format, required, and type from JSON Schema.
This feature was motivated by the SEO/Metatag component schema: https://github.com/deco-pages/start/pull/6 .

### Solution
Now the RenderField component maps the JSON Schema format and checks if the property is required.

#### Changes
1. The form handles the discard, and the save button with the native submit;
2. The discard button doesn't reload the page. Now, the button resets the form state with the components value from the server.

#### Fixes
1. useEditorOperations edit the components (renamed as initialComponents) prop via componentsRef, and this may be root cause of bugs. Now the componentsRef.current has a copy of the components (initialComponents), so the components value won't be changed.