### PR TITLE
feat: Parytown copy files script

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ import MyTestComponent from '../components/MyTestComponent.tsx';
 ```
 ### Copy Partytown files script
 
-The partytown library need the web workers and service workers static files to work, this script copy those required files. More info: https://partytown.builder.io/copy-library-files
+The partytown library needs the web and service workers' static files to work. This script copies these required files. More info: https://partytown.builder.io/copy-library-files
 Add the `copyPartytown` task to your `deno.json` file:
 
 ```json
@@ -126,7 +126,7 @@ Then run the `copyPartytown` task with the first argument destination folder to 
 deno task copyPartytown "./static/~partytown/"
 ```
 
-To copy the debug files pass the flag `--debug`
+Pass the `--debug` flag to also copy Partytown's debug files.
 
 ```bash
 deno task copyPartytown "./static/~partytown/" -- "--debug"

--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ Aditionally, the import snippet will replace your clipboard content:
 ```jsx
 import MyTestComponent from '../components/MyTestComponent.tsx';
 ```
+### Copy Partytown files script
+
+The partytown library need the web workers and service workers static files to work, this script copy those required files. More info: https://partytown.builder.io/copy-library-files
+Add the `copyPartytown` task to your `deno.json` file:
+
+```json
+{
+  "tasks": {
+    // ...
+   "copyPartytown": "deno eval 'import \"$live/scripts/copyPartytownFiles.ts\"'"
+  },
+  "importMap": "./import_map.json"
+}
+```
+
+Then run the `copyPartytown` task with the first argument destination folder to copy partytown files
+
+```bash
+deno task copyPartytown "./static/~partytown/"
+```
+
+To copy the debug files pass the flag `--debug`
+
+```bash
+deno task copyPartytown "./static/~partytown/" -- "--debug"
+```
+
 
 ## Local development
 

--- a/scripts/copyPartytownFiles.ts
+++ b/scripts/copyPartytownFiles.ts
@@ -1,0 +1,70 @@
+import { ensureDirSync } from "https://deno.land/std@0.156.0/fs/mod.ts";
+import { join } from "https://deno.land/std@0.156.0/path/mod.ts";
+
+const partytownUrlPrefix = "https://unpkg.com/@builder.io/partytown@0";
+const partytownFiles = [
+  "partytown.js",
+  "partytown-sw.js",
+  "partytown-media.js",
+  "partytown-atomics.js",
+];
+const partytownDebugFiles = [
+  ...partytownFiles.map((filename) => `/debug/${filename}`),
+  "/debug/partytown-sandbox-sw.js",
+  "/debug/partytown-ww-atomics.js",
+  "/debug/partytown-ww-sw.js",
+];
+
+async function fetchAndWriteFiles(files: string[], dest: string) {
+  const unpkFiles = await Promise.all(
+    files.map((file) =>
+      fetch(`${partytownUrlPrefix}/${file}`).then((res) => res.text())
+    ),
+  );
+
+  files.forEach((fileName, index) => {
+    Deno.writeTextFileSync(
+      join(dest, fileName),
+      unpkFiles[index],
+      { create: true },
+    );
+  });
+}
+
+export async function copyLibFiles(dest: string, opts: { debugDir?: boolean }) {
+  console.log("Creating destination folder:", dest);
+  ensureDirSync(dest);
+
+  console.log("Fetching and writing partytown files...");
+  await fetchAndWriteFiles(partytownFiles, dest);
+
+  if (opts.debugDir) {
+    const debugFolder = join(dest, "./debug/");
+
+    console.log("Debug flag enabled. Creating debug folder: ", debugFolder);
+    ensureDirSync(debugFolder);
+
+    await fetchAndWriteFiles(partytownDebugFiles, dest);
+  }
+
+  console.log("Finished.");
+}
+
+let destination = "";
+const opts = { debugDir: false };
+
+const [arg0, arg1] = Deno.args;
+
+if (typeof arg0 !== "string" || arg0.length === 0 || arg0.startsWith("-")) {
+  throw new Error(
+    "Missing destination directory. \n Run deno task <taskName> <destination_folder>",
+  );
+}
+
+destination = arg0;
+
+if (arg1 === "--debug") {
+  opts.debugDir = true;
+}
+
+copyLibFiles(destination, opts);

--- a/scripts/copyPartytownFiles.ts
+++ b/scripts/copyPartytownFiles.ts
@@ -1,7 +1,7 @@
 import { ensureDirSync } from "https://deno.land/std@0.156.0/fs/mod.ts";
 import { join } from "https://deno.land/std@0.156.0/path/mod.ts";
 
-const partytownUrlPrefix = "https://unpkg.com/@builder.io/partytown@0";
+const partytownUrlPrefix = "https://unpkg.com/@builder.io/partytown@0/lib/";
 const partytownFiles = [
   "partytown.js",
   "partytown-sw.js",

--- a/scripts/copyPartytownFiles.ts
+++ b/scripts/copyPartytownFiles.ts
@@ -32,19 +32,23 @@ async function fetchAndWriteFiles(files: string[], dest: string) {
 }
 
 export async function copyLibFiles(dest: string, opts: { debugDir?: boolean }) {
+  const fullPathDest = join(Deno.cwd(), dest);
   console.log("Creating destination folder:", dest);
   ensureDirSync(dest);
 
   console.log("Fetching and writing partytown files...");
-  await fetchAndWriteFiles(partytownFiles, dest);
+  await fetchAndWriteFiles(partytownFiles, fullPathDest);
 
   if (opts.debugDir) {
-    const debugFolder = join(dest, "./debug/");
+    const debugFolder = join(fullPathDest, "./debug/");
 
-    console.log("Debug flag enabled. Creating debug folder: ", debugFolder);
+    console.log(
+      "Debug flag enabled. Creating debug folder: ",
+      dest.concat("/debug/"),
+    );
     ensureDirSync(debugFolder);
 
-    await fetchAndWriteFiles(partytownDebugFiles, dest);
+    await fetchAndWriteFiles(partytownDebugFiles, fullPathDest);
   }
 
   console.log("Finished.");


### PR DESCRIPTION
### Context
The partytown plugin needs the lib files to instantiate the service worker/web worker, but the partytown copy files CLI doesn't work with Deno.

### Solution
Live exports createPartytownFiles script that creates partytown files at the destination folder passed from the user.
To accomplish this, the script fetches the partytown files from https://unpkg.com/browse/@builder.io/partytown@0.7.0/lib/ folder and saves them in the destination folder.

The unpkg doesn't handle list files from a folder, so, the files are hard coded for instance.