### PR TITLE
chore: update fresh + preact + preact-render-to-string

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -1,15 +1,15 @@
 {
   "imports": {
     "$live/": "./",
-    "$fresh/": "https://deno.land/x/fresh@1.1.0/",
-    "preact": "https://esm.sh/preact@10.10.6",
-    "preact/": "https://esm.sh/preact@10.10.6/",
-    "preact-render-to-string": "https://esm.sh/preact-render-to-string@5.2.0?deps=preact@10.10.6",
+    "$fresh/": "https://deno.land/x/fresh@1.1.2/",
+    "preact": "https://esm.sh/preact@10.11.1",
+    "preact/": "https://esm.sh/preact@10.11.1/",
+    "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.4",
     "tabbable": "https://esm.sh/v91/tabbable@5.3.3/",
     "twind": "https://esm.sh/twind@0.16.17",
     "twind/": "https://esm.sh/twind@0.16.17/",
     "partytown": "https://esm.sh/@builder.io/partytown@0.7.0/integration",
-    "react-hook-form": "https://esm.sh/react-hook-form@7.34.2?deps=preact@10.10.6&alias=react:preact/compat",
+    "react-hook-form": "https://esm.sh/*react-hook-form@7.34.2?alias=react:preact/compat",
     "std/": "https://deno.land/std@0.147.0/",
     "supabase": "https://esm.sh/@supabase/supabase-js@1.35.4"
   }


### PR DESCRIPTION
fresh: 1.1.2
preact: 10.11.1
preact-render-to-string: 5.2.4

Fix react-hook-form to not import dependencies using `*`