### PR TITLE
feat: Live components

### DIFF
--- a/canvas.tsx
+++ b/canvas.tsx
@@ -1,25 +1,17 @@
 import { HandlerContext } from "$fresh/server.ts";
-import { ASSET_CACHE_BUST_KEY } from "$fresh/runtime.ts";
-import { renderToString } from "preact-render-to-string";
-import { context } from "./server.ts";
 import getSupabaseClient, { getSupabaseClientForUser } from "./supabase.ts";
 import type {
   Flag,
-  Module,
   PageComponent,
   PageData,
   PageLoader,
   WithSchema,
 } from "./types.ts";
-import { filenameFromPath } from "./utils/component.ts";
 import { createServerTiming } from "./utils/serverTimings.ts";
 import { duplicateProdPage, getFlagFromPageId } from "./utils/supabase.ts";
 
-const ONE_YEAR_CACHE = "public, max-age=31536000, immutable";
-
 const updateDraft = async (
   req: Request,
-  pathname: string,
   ctx: EditorRequestData,
 ) => {
   const { components, siteId, variantId, experiment, loaders } = ctx;
@@ -178,148 +170,4 @@ export async function updateComponentProps(
 export interface ComponentPreview
   extends Omit<PageComponent, "uniqueId" | "props">, WithSchema {
   link: string;
-}
-
-function mapComponentsToPreview([componentPath, componentModule]: [
-  string,
-  Module,
-]): ComponentPreview | undefined {
-  const { schema } = componentModule;
-
-  if (!schema) {
-    return;
-  }
-
-  const componentRelativePath = filenameFromPath(componentPath);
-
-  return {
-    key: componentPath,
-    link: `/live/api/components/${componentRelativePath}`,
-    label: schema.title ?? componentRelativePath,
-    schema,
-  };
-}
-
-export function componentsPreview(req: Request) {
-  const url = new URL(req.url);
-
-  const { start, end, printTimings } = createServerTiming();
-  const manifest = context.manifest!;
-
-  start("map-components");
-  const components: ComponentPreview[] = Object.entries(manifest.components)
-    .map(mapComponentsToPreview)
-    .filter((componentPreviewData): componentPreviewData is ComponentPreview =>
-      Boolean(componentPreviewData)
-    );
-
-  const islands: ComponentPreview[] = Object.entries(manifest.islands)
-    .map(mapComponentsToPreview)
-    .filter((componentPreviewData): componentPreviewData is ComponentPreview =>
-      Boolean(componentPreviewData)
-    );
-  end("map-components");
-
-  const cache = context.deploymentId !== undefined &&
-    url.searchParams.has(ASSET_CACHE_BUST_KEY);
-
-  return Response.json(
-    { components, islands },
-    {
-      status: 200,
-      headers: {
-        "content-type": "application/json",
-        "Server-Timing": printTimings(),
-        ...(cache
-          ? {
-            "Cache-Control": ONE_YEAR_CACHE,
-          }
-          : {}),
-      },
-    },
-  );
-}
-
-export function renderComponent(req: Request) {
-  const url = new URL(req.url);
-
-  const { start, end, printTimings } = createServerTiming();
-
-  const componentKey = url.searchParams.get("component") ?? "";
-  const Component = context.manifest?.islands[componentKey]?.default ??
-    context.manifest?.components[componentKey]?.default;
-
-  if (!Component) {
-    return new Response("Component Not Found", {
-      status: 404,
-    });
-  }
-
-  let html = "";
-  start("render-component");
-
-  const render = () => {
-    html = renderToString(<Component />);
-
-    // TODO: handle hydration
-    // https://github.com/denoland/fresh/blob/1b3c9f2569c5d56a6d37c366cb5940f26b7e131e/plugins/twind.ts#L24
-
-    return {
-      htmlText: html,
-      requiresHydration: false,
-    };
-  };
-
-  const twindPlugin = context.plugins?.find((plugin) => {
-    return plugin.name === "twind";
-  });
-
-  try {
-    if (twindPlugin) {
-      // Mimic the fresh render function that run plugins.render
-      // https://github.com/denoland/fresh/blob/main/src/server/render.ts#L174
-      const res = twindPlugin.render?.({
-        render,
-      }) ?? {};
-
-      if (res.styles) {
-        const [style] = res.styles;
-
-        const styleNode = (
-          <style
-            id={style.id}
-            dangerouslySetInnerHTML={{ __html: style.cssText }}
-            media={style.media}
-          />
-        );
-
-        const styleString = renderToString(styleNode);
-        html = styleString + html;
-      }
-    } else {
-      render();
-    }
-  } catch (e) {
-    if (url.hostname === "localhost") {
-      throw e;
-    }
-
-    html = renderToString(<div>Failed to load component</div>);
-  }
-  end("render-component");
-
-  const cache = context.deploymentId !== undefined &&
-    url.searchParams.has(ASSET_CACHE_BUST_KEY);
-
-  return new Response(html, {
-    headers: {
-      "content-type": "text/html; charset=utf-8",
-      "Server-Timing": printTimings(),
-      ...(cache
-        ? {
-          "Cache-Control": ONE_YEAR_CACHE,
-        }
-        : {}),
-    },
-  });
 }

--- a/live.tsx
+++ b/live.tsx
@@ -2,17 +2,11 @@ import { Handlers, PageProps } from "$fresh/server.ts";
 import {
   EditorData,
   Page,
-  PageComponent,
   PageData,
-  PageLoader,
 } from "$live/types.ts";
 import InspectVSCodeHandler from "https://deno.land/x/inspect_vscode@0.0.5/handler.ts";
 import { createServerTiming } from "$live/utils/serverTimings.ts";
-import {
-  componentsPreview,
-  renderComponent,
-  updateComponentProps,
-} from "$live/canvas.tsx";
+import { updateComponentProps } from "$live/canvas.tsx";
 import { filenameFromPath, getComponentModule } from "$live/utils/component.ts";
 import type { ComponentChildren } from "preact";
 
@@ -26,8 +20,12 @@ export function live() {
       const url = new URL(req.url);
       // TODO: Find a better way to embedded this route on project routes.
       // Follow up here: https://github.com/denoland/fresh/issues/516
-      if (url.pathname.startsWith("/live/api/components")) {
-        return renderComponent(req);
+      const component = url.searchParams.get('component')
+      if (url.pathname.startsWith('/live/api/components') && typeof component === 'string') {
+        return ctx.render({
+          components: [{key: `./components/${component}`, label: '', uniqueId: '', props: {}}],
+          loaders: []
+        });
       }
 
       const { start, end, printTimings } = createServerTiming();


### PR DESCRIPTION
This PR adds a new behavior to live. When fetch('/live/api/components'), the renderer will render:

```
return ctx.render({
          components: [{key: `./components/${component}`, label: '', uniqueId: '', props: {}}],
          loaders: []
        });
```

This way, we can accomplish screens like: 
<img width="1366" alt="image" src="https://user-images.githubusercontent.com/1753396/198738639-1f66eff8-8c5a-43a4-a3dc-c811326a2e62.png">
