### PR TITLE
feat: Retrieve components list

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -13,5 +13,6 @@
     "std/": "https://deno.land/std@0.147.0/",
     "supabase": "https://esm.sh/@supabase/supabase-js@1.35.4",
     "json-schema": "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts",
+    "inspect_vscode/": "https://deno.land/x/inspect_vscode@0.0.6/"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -13,6 +13,5 @@
     "std/": "https://deno.land/std@0.147.0/",
     "supabase": "https://esm.sh/@supabase/supabase-js@1.35.4",
     "json-schema": "https://esm.sh/v92/@types/json-schema@7.0.11/X-YS9yZWFjdDpwcmVhY3QvY29tcGF0CmQvcHJlYWN0QDEwLjEwLjY/index.d.ts",
-    "inspect_vscode/": "https://deno.land/x/inspect_vscode@0.0.6/"
   }
 }

--- a/live.tsx
+++ b/live.tsx
@@ -49,7 +49,7 @@ export function live() {
               ) // allow components/[component].tsx only
               .map((component) => ({
                 name: component.replace("./components/", ""),
-                path: component,
+                path: component.replace("./", ""),
                 link: `vscode://file/${resolveFilePath(component)}`,
               }))
           ),

--- a/live.tsx
+++ b/live.tsx
@@ -8,6 +8,7 @@ import { filenameFromPath, getComponentModule } from "$live/utils/component.ts";
 import { context } from "$live/server.ts";
 import { loadData, loadLivePage } from "$live/pages.ts";
 import { ___tempMigratePageData } from "./utils/supabase.ts";
+import { resolveFilePath } from "./utils/filesystem.ts";
 
 export function live() {
   const handler: Handlers<Page> = {
@@ -40,10 +41,17 @@ export function live() {
 
         return new Response(
           JSON.stringify(
-            Object.keys(context.manifest?.components ?? {}).filter(
-              (component) =>
-                component.split("/").length === 3 && component.endsWith(".tsx")
-            ) // allow components/[component].tsx only
+            Object.keys(context.manifest?.components ?? {})
+              .filter(
+                (component) =>
+                  component.split("/").length === 3 &&
+                  component.endsWith(".tsx")
+              ) // allow components/[component].tsx only
+              .map((component) => ({
+                name: component.replace("./components/", ""),
+                path: component,
+                link: `vscode://file/${resolveFilePath(component)}`,
+              }))
           ),
           {
             status: 200,

--- a/live.tsx
+++ b/live.tsx
@@ -50,13 +50,17 @@ export function live() {
               .map((component) => ({
                 name: component.replace("./components/", ""),
                 path: component.replace("./", ""),
-                link: `vscode://file/${resolveFilePath(component)}`,
+                link:
+                  context.deploymentId === undefined // only allow vscode when developing locally
+                    ? `vscode://file/${resolveFilePath(component)}`
+                    : undefined,
               }))
           ),
           {
             status: 200,
             headers: {
               "content-type": "application/json",
+              "Access-Control-Allow-Origin": "*",
             },
           }
         );

--- a/live.tsx
+++ b/live.tsx
@@ -13,29 +13,45 @@ export function live() {
   const handler: Handlers<Page> = {
     async GET(req, ctx) {
       const url = new URL(req.url);
+
       // TODO: Find a better way to embedded this route on project routes.
       // Follow up here: https://github.com/denoland/fresh/issues/516
-      const component = url.searchParams.get("component");
-      if (
-        url.pathname.startsWith("/live/api/components") &&
-        typeof component === "string"
-      ) {
-        return ctx.render({
-          id: -1,
-          name: "The Impossible Page",
-          path: "/",
-          data: {
-            components: [
-              {
-                key: `./components/${component}`,
-                label: "",
-                uniqueId: "",
-                props: {},
-              },
-            ],
-            loaders: [],
-          },
-        });
+      if (url.pathname.startsWith("/_live/components")) {
+        const component = url.searchParams.get("component");
+
+        if (component) {
+          return ctx.render({
+            id: -1,
+            name: "The Impossible Page",
+            path: "/",
+            data: {
+              components: [
+                {
+                  key: component,
+                  label: "",
+                  uniqueId: "",
+                  props: {},
+                },
+              ],
+              loaders: [],
+            },
+          });
+        }
+
+        return new Response(
+          JSON.stringify(
+            Object.keys(context.manifest?.components ?? {}).filter(
+              (component) =>
+                component.split("/").length === 3 && component.endsWith(".tsx")
+            ) // allow components/[component].tsx only
+          ),
+          {
+            status: 200,
+            headers: {
+              "content-type": "application/json",
+            },
+          }
+        );
       }
 
       const { start, end, printTimings } = createServerTiming();

--- a/utils/filesystem.ts
+++ b/utils/filesystem.ts
@@ -1,0 +1,7 @@
+import { context } from "$live/server.ts";
+
+import { join, fromFileUrl } from 'std/path/mod.ts'
+
+export const resolveFilePath = (path: string) => {
+  return join(fromFileUrl(context.manifest?.baseUrl ?? ""), '..', path)
+}


### PR DESCRIPTION
This PR adds a new api for retrieving components:

`/live/api/components` returns the components list in json format 
```
{
name: string // label
path: string // component relative path to root
link:string // vscode link path
}
```
`/live/api/components?component={}` renders that component in a context
