### PR TITLE
feat: Add component editor

### DIFF
--- a/pages.ts
+++ b/pages.ts
@@ -1,16 +1,21 @@
 import { HandlerContext } from "$fresh/server.ts";
-import { PageData } from "$live/types.ts";
-import { fetchPageFromId, fetchPageFromPathname } from "./utils/supabase.ts";
-import { isLoaderProp, propToLoaderInstance } from "./utils/loaders.ts";
 import { context } from "$live/server.ts";
-import { path } from "./utils/path.ts";
+import { PageData } from "$live/types.ts";
+
 import { Page } from "./types.ts";
+import { isLoaderProp, propToLoaderInstance } from "./utils/loaders.ts";
+import { path } from "./utils/path.ts";
+import { fetchPageFromComponent, fetchPageFromId, fetchPageFromPathname } from "./utils/supabase.ts";
 
 export async function loadLivePage(req: Request): Promise<Page> {
   const url = new URL(req.url);
-  const pageId = parseInt(url.searchParams.get("pageId")!, 10);
+  const pageIdParam = url.searchParams.get("pageId");
+  const component = url.searchParams.get("component");
+  const pageId = pageIdParam && parseInt(pageIdParam, 10);
 
-  const page = pageId
+  const page = component
+    ? await fetchPageFromComponent(component)
+    : pageId
     ? await fetchPageFromId(pageId)
     : await fetchPageFromPathname(url.pathname, context.siteId);
 

--- a/utils/component.ts
+++ b/utils/component.ts
@@ -1,4 +1,16 @@
-import type { DecoManifest, Module } from "../types.ts";
+import { propertyHasRef } from "./schema.ts";
+import { context } from "../server.ts";
+import { resolveFilePath } from "./filesystem.ts";
+
+import type { DecoManifest, Loader, Module, Page, PageData } from "../types.ts";
+import { appendHash, loaderInstanceToProp } from "./loaders.ts";
+
+interface ComponentInstance {
+  key: string;
+  label: string;
+  uniqueId: string;
+  props: Record<string, unknown>;
+}
 
 /**
  * TODO: There's probably a file util for that
@@ -27,9 +39,105 @@ export function isValidIsland(componentPath: string) {
   return !BLOCKED_ISLANDS_SCHEMAS.has(componentPath);
 }
 
+// Creates a fake page from a component
 export function getComponentModule(
   manifest: DecoManifest,
   key: string
 ): Module | undefined {
   return manifest.islands?.[key] ?? manifest.components?.[key];
 }
+
+export const getComponentList = () =>
+  Object.keys(context.manifest?.components ?? {})
+    .filter(
+      (component) =>
+        component.split("/").length === 3 && component.endsWith(".tsx"),
+    ) // allow components/[component].tsx only
+    .map((component) => ({
+      name: component.replace("./components/", ""),
+      path: component.replace("./", ""),
+      link: context.deploymentId === undefined // only allow vscode when developing locally
+        ? `vscode://file/${resolveFilePath(component)}`
+        : undefined,
+    }));
+
+export const createLoadersForComponent = (instance: ComponentInstance) => {
+  const loaders = context.manifest?.loaders ?? {};
+  const loadersByOutputSchema = Object
+    .entries(loaders)
+    .reduce(
+      (acc, [key, loader]) => ({
+        ...acc,
+        [loader?.default?.outputSchema?.$ref]: {
+          loader: loader.default,
+          key,
+        },
+      }),
+      {} as Record<string, { key: string; loader: Loader }>,
+    );
+
+  const definition = getDefinition(instance.key);
+  if (!definition) {
+    throw new Error(`Component ${instance.key} not found`);
+  }
+
+  const loaderInstances = Object
+    .keys(definition.schema?.properties ?? {})
+    .filter((propName) => propertyHasRef(definition.schema, propName))
+    .map((propName) => {
+      const outputSchema = (definition.schema?.properties?.[propName] as any)
+        ?.$ref;
+
+      const match = loadersByOutputSchema[outputSchema];
+
+      if (!match) {
+        throw new Error(
+          `Loader for ${outputSchema} not found for <${instance}/>`,
+        );
+      }
+
+      const loaderUniqueId = appendHash(outputSchema);
+      instance.props[propName] = loaderInstanceToProp(loaderUniqueId);
+
+      return {
+        key: match.key,
+        label: match.key,
+        outputSchema: outputSchema,
+        uniqueId: loaderUniqueId,
+        props: {},
+        schema: match.loader.inputSchema,
+      };
+    });
+
+  return loaderInstances;
+};
+
+export const createComponent = (componentKey: string) => {
+  const component: ComponentInstance = {
+    key: componentKey,
+    label: componentKey,
+    uniqueId: componentKey,
+    props: {},
+  };
+
+  const loaders = createLoadersForComponent(component);
+
+  return {
+    component,
+    loaders,
+  };
+};
+
+export const createPageForComponent = (
+  componentName: string,
+  data: PageData,
+): Page => ({
+  id: -1,
+  name: componentName,
+  path: `/_live/components/${componentName}`,
+  data,
+});
+
+const getDefinition = (path: string) => context.manifest?.components[path];
+
+export const exists = (path: string) => Boolean(getDefinition(path));

--- a/utils/schema.ts
+++ b/utils/schema.ts
@@ -1,0 +1,10 @@
+import type { JSONSchema7 } from "json-schema";
+
+export const propertyHasRef = (
+  schema: JSONSchema7 | undefined,
+  propKey: string,
+) => {
+  // Property is undefined | boolean | object, so if property[key] is === "object" and $ref in property[key]
+  return (typeof schema?.properties?.[propKey]) === "object" &&
+    "$ref" in (schema?.properties?.[propKey] as JSONSchema7);
+};


### PR DESCRIPTION
This PR adds <Editor/> component to the component viewer. 

The ideia behind this PR is to create a fake page for each component where the only component on that page is the component being edited. This is ok for now because it allows us to reuse many components created for editing the pages.

The mechanism used for rendering components is the same one used for rendering pages. fetch `/?component={componentName}` for getting a page rendered for that component. If the page component already exists on the database, this page is returned. A new fake page is returned if it doesn't exist on the database. This fake page will be persisted on the database once the user clicks on "Save Draft".
These component pages are created under the path `/_live/components/{ComponentName}.tsx`

