### PR TITLE
Implementing dynamic routing using URLPattern

### DIFF
--- a/live.tsx
+++ b/live.tsx
@@ -44,9 +44,16 @@ export function live() {
       // end("load-flags");
 
       start("load-page");
-      const page = await loadLivePage(req);
-      console.log({ "Found Page": page });
+      const pageWithParams = await loadLivePage(req);
       end("load-page");
+
+      if (!pageWithParams) {
+        return ctx.renderNotFound();
+      }
+
+      const { page, params = {} } = pageWithParams;
+
+      console.log({ "Found Page": page });
 
       if (url.searchParams.has("editorData")) {
         const editorData = generateEditorData(page);
@@ -60,7 +67,10 @@ export function live() {
       start("load-data");
       const pageDataAfterLoaders = await loadData(
         req,
-        ctx,
+        {
+          ...ctx,
+          params,
+        },
         page?.data,
         start,
         end,

--- a/pages.ts
+++ b/pages.ts
@@ -204,30 +204,28 @@ export const fetchPageFromComponent = async (
  * Sort pages by their relative routing priority, based on the parts in the
  * route matcher
  *
- * Extracted from: https://github.com/denoland/fresh/blob/046fcde959041ac9cd5f2b39671c819c4af5cc24/src/server/context.ts#L683
+ * Logic extracted from:
+ * https://github.com/denoland/fresh/blob/046fcde959041ac9cd5f2b39671c819c4af5cc24/src/server/context.ts#L683
+ * 
  */
 export function sortRoutes<T extends { pattern: string }>(routes: T[]) {
-  routes.sort((a, b) => {
-    const partsA = a.pattern.split("/");
-    const partsB = b.pattern.split("/");
-    for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
-      const partA = partsA[i];
-      const partB = partsB[i];
-      if (partA === undefined) return -1;
-      if (partB === undefined) return 1;
-      if (partA === partB) continue;
-      const priorityA = partA.startsWith(":")
-        ? partA.endsWith("*")
-          ? 0
-          : 1
-        : 2;
-      const priorityB = partB.startsWith(":")
-        ? partB.endsWith("*")
-          ? 0
-          : 1
-        : 2;
-      return Math.max(Math.min(priorityB - priorityA, 1), -1);
-    }
-    return 0;
-  });
+  const rankRoute = (pattern: string) => {
+    let routeScore = 0;
+    const parts = pattern.split("/");
+    parts.forEach((routePart) => {
+      if (!routePart) {
+        return;
+      }
+      if (routePart.endsWith("*")) {
+        routeScore += 0;
+      } else if (routePart.startsWith(":")) {
+        routeScore += 1;
+      } else {
+        routeScore += 2;
+      }
+    });
+
+    return routeScore;
+  };
+  routes.sort((a, z) => rankRoute(z.pattern) - rankRoute(a.pattern));
 }

--- a/types.ts
+++ b/types.ts
@@ -9,11 +9,7 @@ export interface Module extends IslandModule {
 }
 
 export interface Loader {
-  loader: (
-    req: Request,
-    ctx: HandlerContext<any>,
-    props: any,
-  ) => Promise<any>;
+  loader: (req: Request, ctx: HandlerContext<any>, props: any) => Promise<any>;
   inputSchema: JSONSchema7;
   outputSchema: { $ref: NonNullable<JSONSchema7["$ref"]> };
 }
@@ -65,6 +61,16 @@ export interface Page {
   data: PageData;
   name: string;
   path: string;
+}
+
+/**
+ * This type is used only on the render flow, after we matched an URL path
+ * and possibly found page params (e.g: "/:slug/p" with the url "/blouse/p"
+ * generates params: { slug: "blouse"})
+ */
+export interface PageWithParams {
+  page: Page;
+  params?: Record<string, string>;
 }
 
 export interface Flag {


### PR DESCRIPTION
This PR completes Live routing capabilities for dynamic routes (e.g: `/:slug/p`), without the need to manually add those routes to the project. It also organizes some functions.

It uses the very handy [URLPattern](https://developer.mozilla.org/en-US/docs/Web/API/URLPattern/exec) web API, which Fresh internally also uses it via [rutt](https://deno.land/x/rutt@0.0.13).

<img width="759" alt="image" src="https://user-images.githubusercontent.com/18706156/199640737-a405e59c-ab4d-47dd-8819-7cacd84db230.png">


One implication we have is that now **we're fetching all production routes for every render**, which can be optimized later. I took a look at the measures and couldn't notice any difference (the timings vary a lot for `loadPage`).

**Before:**
<img width="934" alt="Screen Shot 2022-11-02 at 21 18 25" src="https://user-images.githubusercontent.com/18706156/199640331-c1f352c1-4ee9-4bcf-8c67-0963d8d17eb4.png">

**After:**
<img width="928" alt="Screen Shot 2022-11-03 at 00 04 56" src="https://user-images.githubusercontent.com/18706156/199640344-8167a536-bb5b-473c-8f68-e48fe6ca2261.png">

--

There was also some changes in `fetchPageFromId` after I realized that, even for those cases, we'd still need the page's URL to generate params because some loaders/functions will probably need it (e.g: `/blouse/p?pageId=411`, where we want to render a version of the Product Page)