### PR TITLE
feat: Terminal aesthetics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,8 @@
   "editor.defaultFormatter": "denoland.vscode-deno",
   "[markdown]": {
     "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
   }
 }

--- a/live.tsx
+++ b/live.tsx
@@ -27,7 +27,7 @@ const formatLog = (opts: {
     ? yellow
     : red;
   const duration = ((performance.now() - opts.begin) / 1e3).toFixed(0);
-  const { path, id, name } = opts.page;
+  const { path, id } = opts.page;
 
   if (DEPLOY) {
     return `[${
@@ -35,7 +35,7 @@ const formatLog = (opts: {
     }]: ${duration}ms ${path} ${opts.url.pathname} ${id}`;
   }
 
-  return `[${statusFormatter(`${opts.status}`)}]: ${duration}ms ${name} ${
+  return `[${statusFormatter(`${opts.status}`)}]: ${duration}ms ${
     magenta(path)
   } ${cyan(opts.url.pathname)} ${green(`https://deco.cx/live/${context.siteId}/pages/${id}`)}`;
 };


### PR DESCRIPTION
This PR improves `live` feedback by removing a console.log we did to a better formatted terminal:

Before/After can be seen below:
<img width="427" alt="image" src="https://user-images.githubusercontent.com/1753396/200891587-4e0b8c9d-4eb8-4513-8796-dc7cc4202094.png">
<img width="946" alt="image" src="https://user-images.githubusercontent.com/1753396/200891974-ce53569b-87c3-42e2-a212-d6a71429731c.png">
