### PR TITLE
chore: Use new state for fetch pages and avoid going on db twice

### DIFF
--- a/pages.ts
+++ b/pages.ts
@@ -117,11 +117,10 @@ export const fetchPageFromPathname = async (
   siteId: number,
 ): Promise<PageWithParams | null> => {
   const { data: pages, error } = await getSupabaseClient()
-    .from("pages")
+    .from<Page & { site: number }>("pages")
     .select("id, name, data, path, state")
-    .match({ site: siteId, archived: false })
-    .is("flag", null)
-    .is("archived", false);
+    .eq("site", siteId)
+    .eq("state", "published");
 
   const routes = pages?.map((page) => ({
     page,
@@ -157,7 +156,7 @@ export const fetchPageFromId = async (
   pathname?: string,
 ): Promise<PageWithParams> => {
   const { data: pages, error } = await getSupabaseClient()
-    .from("pages")
+    .from<Page>("pages")
     .select("id, name, data, path, state")
     .match({ id: pageId });
 
@@ -206,13 +205,13 @@ export const fetchPageFromComponent = async (
 
   const { data } = await supabase
     .from<Page>("pages")
-    .select("id, path")
+    .select("id, name, data, path, state")
     .match({ path: page.path, site: siteId });
 
   const match = data?.[0];
 
   if (match) {
-    return fetchPageFromId(match.id);
+    return { page: match };
   }
 
   return { page };


### PR DESCRIPTION
Test running 30 times to get data on supabase.
```ts
// before
await client
    .from("pages")
    .select("id, name, data, path, state")
    .eq("site", siteId)
    .eq("archived", false)
    .is("flag", null);
    
// after
await client
    .from("pages")
    .select("id, name, data, path, state")
    .eq("site", siteId)
    .eq("state", "published");
  const res = (performance.now() - begin);
```

Before:
|  media |  p90  | p95  | p99 | 
| --- | --- | --- | --- |
 | 127.0514385333333 | 144.73032150000006 | 150.68236399999978 | 297.68789 |

After:
|  media |  p90  | p95  | p99 | 
| --- | --- | --- | --- |
| 118.03299983333332 | 125.51731000000007 | 137.7168929999998 | 259.58971399999996 |