### PR TITLE
feat: Web Vitals

### DIFF
--- a/components/CoreWebVitals.tsx
+++ b/components/CoreWebVitals.tsx
@@ -1,0 +1,31 @@
+import Script from "partytown/Script.tsx";
+import { Page } from "$live/types.ts";
+
+const innerHtml = ({ id, path }: Page) => `
+import { onCLS, onFID, onLCP } from "https://esm.sh/web-vitals@3.1.0";
+
+function onWebVitalsReport(event) {
+  if (typeof window.jitsu === "function") {
+    window.jitsu('track', 'web-vitals', { ...event, page_id: "${id}", page_path: "${path}" });
+  }
+};
+
+onCLS(onWebVitalsReport);
+onFID(onWebVitalsReport);
+onLCP(onWebVitalsReport);
+`;
+
+interface Props {
+  page: Page;
+}
+
+function CoreWebVitals({ page }: Props) {
+  return (
+    <Script
+      type="module"
+      dangerouslySetInnerHTML={{ __html: innerHtml(page) }}
+    />
+  );
+}
+
+export default CoreWebVitals;

--- a/live.tsx
+++ b/live.tsx
@@ -10,6 +10,7 @@ import { createServerTiming } from "$live/utils/serverTimings.ts";
 import InspectVSCodeHandler from "inspect_vscode/handler.ts";
 import { blue, cyan, green, magenta, red, yellow } from "std/fmt/colors.ts";
 import Jitsu from "partytown/integrations/Jitsu.tsx";
+import CoreWebVitals from "./components/CoreWebVitals.tsx";
 
 import { getWorkbenchTree } from "./utils/workbench.ts";
 
@@ -179,6 +180,7 @@ export function LivePage({
       {DEPLOY && ( // Add analytcs in production only
         <Jitsu data-key="js.9wshjdbktbdeqmh282l0th.c354uin379su270joldy2" />
       )}
+      <CoreWebVitals page={data} />
 
       {children ? children : <LiveSections {...data.data} />}
 


### PR DESCRIPTION
This PR adds web-vitals report to all live sites.

It uses Google's web vitals library to add reporting to all sites. A nice thing is that it's integrated with our `pages` data, so we can cross reference web vitals to page ids and page path templates

To upgrade your site, just bump your live's version in your import_map.json

To know more: https://www.loom.com/share/f517456700124677b453745daa37dbcf