### PR TITLE
feat: Add site id to analytics dimention

### DIFF
--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -1,4 +1,4 @@
-import Script from "https://deno.land/x/partytown@0.0.7/Script.tsx";
+import Script from "https://deno.land/x/partytown@0.1.0/Script.tsx";
 import { Page, Site } from "$live/types.ts";
 
 const innerHtml = ({ id, path }: Page, { id: siteId }: Site) => `

--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -1,12 +1,12 @@
 import Script from "https://deno.land/x/partytown@0.0.7/Script.tsx";
-import { Page } from "$live/types.ts";
+import { Page, Site } from "$live/types.ts";
 
-const innerHtml = ({ id, path }: Page) => `
+const innerHtml = ({ id, path }: Page, { id: siteId }: Site) => `
 import { onCLS, onFID, onLCP } from "https://esm.sh/web-vitals@3.1.0";
 
 function onWebVitalsReport(event) {
   if (typeof window.jitsu === "function") {
-    window.jitsu('track', 'web-vitals', { ...event, page_id: "${id}", page_path: "${path}" });
+    window.jitsu('track', 'web-vitals', { ...event, page_id: "${id}", page_path: "${path}", site_id: "${siteId}" });
   }
 };
 
@@ -17,15 +17,16 @@ onLCP(onWebVitalsReport);
 
 interface Props {
   page: Page;
+  site: Site
 }
 
-function CoreWebVitals({ page }: Props) {
+function LiveAnalytics({ page, site }: Props) {
   return (
     <Script
       type="module"
-      dangerouslySetInnerHTML={{ __html: innerHtml(page) }}
+      dangerouslySetInnerHTML={{ __html: innerHtml(page, site) }}
     />
   );
 }
 
-export default CoreWebVitals;
+export default LiveAnalytics;

--- a/components/LivePage.tsx
+++ b/components/LivePage.tsx
@@ -2,9 +2,9 @@ import type { ComponentChildren } from "preact";
 import { PageProps } from "$fresh/server.ts";
 import { context } from "$live/live.ts";
 import { Page } from "$live/types.ts";
-import CoreWebVitals from "$live/components/CoreWebVitals.tsx";
+import LiveAnalytics from "$live/components/LiveAnalytics.tsx";
 import LiveSections from "$live/components/LiveSections.tsx";
-import Jitsu from "https://deno.land/x/partytown@0.0.7/integrations/Jitsu.tsx";
+import Jitsu from "https://deno.land/x/partytown@0.1.0/integrations/Jitsu.tsx";
 
 const EmptyPage = () => (
   <div>
@@ -17,9 +17,10 @@ const EmptyPage = () => (
 export default function LivePage({
   data: page,
   children,
-}: PageProps<Page> & {
+}: PageProps<Page | undefined> & {
   children?: ComponentChildren;
 }) {
+  const site = { name: context.site, id: context.siteId };
   const manifest = context.manifest!;
   // TODO: Read this from context
   const LiveControls = !context.isDeploy &&
@@ -33,7 +34,7 @@ export default function LivePage({
 
       {
         // Track only managed pages
-        page && <CoreWebVitals page={page} />
+        page && <LiveAnalytics page={page} site={site} />
       }
 
       {children

--- a/live.ts
+++ b/live.ts
@@ -148,6 +148,6 @@ export const live: () => Handlers<Page, WithLiveState> = () => ({
       ctx.renderNotFound();
     }
     // TODO: If !isDeploy, render "create new page" component
-    return ctx.render(page as Page);
+    return ctx.render(page);
   },
 });


### PR DESCRIPTION
This PR makes two things:
1. Renames CoreWebVitals component to LiveAnalytics for better naming fit
2. add siteId to the analytics so we know which metric is coming from which site
3. Fix some typings on a few files