### PR TITLE
feat: Add site_id to metrics

### DIFF
--- a/components/LiveAnalytics.tsx
+++ b/components/LiveAnalytics.tsx
@@ -1,23 +1,39 @@
-import Script from "https://deno.land/x/partytown@0.1.0/Script.tsx";
+import Script from "https://deno.land/x/partytown@0.1.3/Script.tsx";
 import { Page, Site } from "$live/types.ts";
 
 const innerHtml = ({ id, path }: Page, { id: siteId }: Site) => `
 import { onCLS, onFID, onLCP } from "https://esm.sh/web-vitals@3.1.0";
 
 function onWebVitalsReport(event) {
-  if (typeof window.jitsu === "function") {
-    window.jitsu('track', 'web-vitals', { ...event, page_id: "${id}", page_path: "${path}", site_id: "${siteId}" });
-  }
+  window.jitsu('track', 'web-vitals', event);
 };
 
-onCLS(onWebVitalsReport);
-onFID(onWebVitalsReport);
-onLCP(onWebVitalsReport);
+function init() {
+  if (typeof window.jitsu !== "function") {
+    return;
+  }
+
+  /* Add these trackers to all analytics sent to our server */
+  window.jitsu('set', { page_id: "${id}", page_path: "${path}", site_id: "${siteId}" });
+  /* Send page-view event */
+  window.jitsu('track', 'pageview');
+
+  /* Listen web-vitals */
+  onCLS(onWebVitalsReport);
+  onFID(onWebVitalsReport);
+  onLCP(onWebVitalsReport);
+};
+
+if (document.readyState === 'complete') {
+  init();
+} else {
+  window.addEventListener('load', init);
+};
 `;
 
 interface Props {
   page: Page;
-  site: Site
+  site: Site;
 }
 
 function LiveAnalytics({ page, site }: Props) {

--- a/components/LivePage.tsx
+++ b/components/LivePage.tsx
@@ -4,7 +4,7 @@ import { context } from "$live/live.ts";
 import { Page } from "$live/types.ts";
 import LiveAnalytics from "$live/components/LiveAnalytics.tsx";
 import LiveSections from "$live/components/LiveSections.tsx";
-import Jitsu from "https://deno.land/x/partytown@0.1.0/integrations/Jitsu.tsx";
+import Jitsu from "https://deno.land/x/partytown@0.1.3/integrations/Jitsu.tsx";
 
 const EmptyPage = () => (
   <div>
@@ -29,13 +29,14 @@ export default function LivePage({
   return (
     <>
       {context.isDeploy && ( // Add analytcs in production only
-        <Jitsu data-key="js.9wshjdbktbdeqmh282l0th.c354uin379su270joldy2" />
+        <Jitsu
+          data-init-only="true"
+          data-key="js.9wshjdbktbdeqmh282l0th.c354uin379su270joldy2"
+        />
       )}
 
-      {
-        // Track only managed pages
-        page && <LiveAnalytics page={page} site={site} />
-      }
+      {/* Track only managed pages */}
+      {page && <LiveAnalytics page={page} site={site} />}
 
       {children
         ? children


### PR DESCRIPTION
This PR adds site_id, page_id and page_path to all events sent to jitsu. This will allow us to properly filter events on our dashboard