### PR TITLE
fix: editor with loaders

### DIFF
--- a/live.ts
+++ b/live.ts
@@ -125,18 +125,20 @@ export const withLive = (
       return workbenchHandler();
     }
 
-    // Let rendering occur — handlers are responsible for calling ctx.state.loadPage
-    const res = await ctx.next();
-
     // Allow introspection of page by editor
-    if (url.searchParams.has("editorData") && ctx.state.page) {
-      const editorData = generateEditorData(ctx.state.page as Page);
+    if (url.searchParams.has("editorData")) {
+      const pageId = url.searchParams.get("pageId");
+      const editorData = await generateEditorData(req, pageId);
+
       return Response.json(editorData, {
         headers: {
           "Access-Control-Allow-Origin": "*",
         },
       });
     }
+
+    // Let rendering occur — handlers are responsible for calling ctx.state.loadPage
+    const res = await ctx.next();
 
     // Print server timings for diagnostics
     res.headers.set("Server-Timing", printTimings());


### PR DESCRIPTION
When using the page editor with loaders we had an error being thrown because the data being returned to the editor already had the loaders resolved. This PR addresses this issue by creating a custom function for editor data