### PR TITLE
fix: legacy api usage with picture element

### DIFF
--- a/std/ui/components/Image.tsx
+++ b/std/ui/components/Image.tsx
@@ -1,11 +1,11 @@
 import { Head } from "$fresh/runtime.ts";
+import { forwardRef } from "preact/compat";
 import ImageKit from "https://esm.sh/imagekit-javascript@1.5.4";
-import type { ComponentType, JSX } from "preact";
+import type { JSX } from "preact";
 
-type Props<T extends "img" | "source" = "img"> =
-  & Omit<JSX.IntrinsicElements[T], "width" | "height" | "preload" | "as">
+type Props =
+  & Omit<JSX.IntrinsicElements["img"], "width" | "height" | "preload">
   & {
-    as?: T;
     width: number;
     height: number;
     src: string;
@@ -33,25 +33,24 @@ export const rescale = (
   });
 
 export const getSrcSet = (src: string, width: number, height: number) =>
-  FACTORS.map((factor) => {
-    const w = width * factor;
-    const h = height * factor;
+  FACTORS
+    .map((factor) => {
+      const w = width * factor;
+      const h = height * factor;
 
-    return `${rescale(src, w, h)} ${w}w`;
-  });
+      return `${rescale(src, w, h)} ${w}w`;
+    })
+    .join(", ");
 
-const Image = <T extends "img" | "source">(props: Props<T>) => {
-  const { preload, loading = "lazy", as = "img" } = props;
-  const Component = as as unknown as ComponentType<JSX.IntrinsicElements[T]>;
+const Image = forwardRef<HTMLImageElement, Props>((props, ref) => {
+  const { preload, loading = "lazy" } = props;
 
-  const sources = getSrcSet(props.src, props.width, props.height);
-  const srcSet = sources.join(", ");
-
+  const srcSet = getSrcSet(props.src, props.width, props.height);
   const linkProps = {
-    imagesrcset: srcSet,
-    imagesizes: props.sizes,
+    imageSrcSet: srcSet,
+    imageSizes: props.sizes,
     fetchpriority: props.fetchPriority,
-    media: props.media
+    media: props.media,
   };
 
   return (
@@ -66,15 +65,16 @@ const Image = <T extends "img" | "source">(props: Props<T>) => {
           />
         </Head>
       )}
-      <Component
+      <img
         {...props}
         preload={undefined}
         src={props.src}
         srcSet={srcSet}
         loading={loading}
+        ref={ref}
       />
     </>
   );
-};
+});
 
 export default Image;

--- a/std/ui/components/Picture.tsx
+++ b/std/ui/components/Picture.tsx
@@ -23,57 +23,57 @@ type SourceProps =
     fetchPriority?: "high" | "low" | "auto";
   };
 
-const Source = forwardRef<HTMLSourceElement, SourceProps>((props, ref) => {
-  const { preload } = useContext(Context);
+export const Source = forwardRef<HTMLSourceElement, SourceProps>(
+  (props, ref) => {
+    const { preload } = useContext(Context);
 
-  const srcSet = getSrcSet(props.src, props.width, props.height);
-  const linkProps = {
-    imagesrcset: srcSet,
-    imagesizes: props.sizes,
-    fetchpriority: props.fetchPriority,
-    media: props.media,
-  };
+    const srcSet = getSrcSet(props.src, props.width, props.height);
+    const linkProps = {
+      imagesrcset: srcSet,
+      imagesizes: props.sizes,
+      fetchpriority: props.fetchPriority,
+      media: props.media,
+    };
 
-  return (
-    <>
-      {preload && (
-        <Head>
-          <link
-            as="image"
-            rel="preload"
-            href={props.src}
-            {...linkProps}
-          />
-        </Head>
-      )}
-      <source
-        {...props}
-        preload={undefined}
-        src={undefined} // Avoid deprecated api lighthouse warning
-        srcSet={srcSet}
-        ref={ref}
-      />
-    </>
-  );
-});
+    return (
+      <>
+        {preload && (
+          <Head>
+            <link
+              as="image"
+              rel="preload"
+              href={props.src}
+              {...linkProps}
+            />
+          </Head>
+        )}
+        <source
+          {...props}
+          preload={undefined}
+          src={undefined} // Avoid deprecated api lighthouse warning
+          srcSet={srcSet}
+          ref={ref}
+        />
+      </>
+    );
+  },
+);
 
 type Props = Omit<JSX.IntrinsicElements["picture"], "preload"> & {
   children: ComponentChildren;
   preload?: boolean;
 };
 
-function Picture({ children, preload, ...props }: Props) {
-  const value = useMemo(() => ({ preload }), [preload]);
+export const Picture = forwardRef<HTMLPictureElement, Props>(
+  ({ children, preload, ...props }, ref) => {
+    const value = useMemo(() => ({ preload }), [preload]);
 
-  return (
-    <Context.Provider value={value}>
-      <picture {...props}>
-        {children}
-      </picture>
-    </Context.Provider>
-  );
-}
-
-Picture.Source = Source;
-
-export default Picture;
+    return (
+      <Context.Provider value={value}>
+        <picture {...props} ref={ref}>
+          {children}
+        </picture>
+      </Context.Provider>
+    );
+  },
+);

--- a/std/ui/components/Picture.tsx
+++ b/std/ui/components/Picture.tsx
@@ -1,6 +1,17 @@
-import type { ComponentChildren, JSX } from "preact";
+import { useContext, useMemo } from "preact/hooks";
+import { forwardRef } from "preact/compat";
+import { ComponentChildren, createContext, JSX } from "preact";
+import { Head } from "$fresh/runtime.ts";
 
-import Image from "./Image.tsx";
+import { getSrcSet } from "./Image.tsx";
+
+interface Context {
+  preload?: boolean;
+}
+
+const Context = createContext<Context>({
+  preload: false,
+});
 
 type SourceProps =
   & Omit<JSX.IntrinsicElements["source"], "width" | "height" | "preload">
@@ -12,19 +23,54 @@ type SourceProps =
     fetchPriority?: "high" | "low" | "auto";
   };
 
-function Source(props: SourceProps) {
-  return <Image {...props} as="source" />;
-}
+const Source = forwardRef<HTMLSourceElement, SourceProps>((props, ref) => {
+  const { preload } = useContext(Context);
 
-type Props = JSX.IntrinsicElements["picture"] & {
+  const srcSet = getSrcSet(props.src, props.width, props.height);
+  const linkProps = {
+    imagesrcset: srcSet,
+    imagesizes: props.sizes,
+    fetchpriority: props.fetchPriority,
+    media: props.media,
+  };
+
+  return (
+    <>
+      {preload && (
+        <Head>
+          <link
+            as="image"
+            rel="preload"
+            href={props.src}
+            {...linkProps}
+          />
+        </Head>
+      )}
+      <source
+        {...props}
+        preload={undefined}
+        src={undefined} // Avoid deprecated api lighthouse warning
+        srcSet={srcSet}
+        ref={ref}
+      />
+    </>
+  );
+});
+
+type Props = Omit<JSX.IntrinsicElements["picture"], "preload"> & {
   children: ComponentChildren;
+  preload?: boolean;
 };
 
-function Picture({ children, ...props }: Props) {
+function Picture({ children, preload, ...props }: Props) {
+  const value = useMemo(() => ({ preload }), [preload]);
+
   return (
-    <picture {...props}>
-      {children}
-    </picture>
+    <Context.Provider value={value}>
+      <picture {...props}>
+        {children}
+      </picture>
+    </Context.Provider>
   );
 }
 


### PR DESCRIPTION
This PR fixes a lighthouse warning of the picture element. Also, moves the preload globally to the picture element. To preload an image, just
```tsx
<Picture preload >
   <Picture.Source src="..." />
   <Picture.Source src="..." />
<Picture/>
```