### PR TITLE
Enabling LiveControls in production (fixes scroll to section)

### DIFF
--- a/components/LivePage.tsx
+++ b/components/LivePage.tsx
@@ -21,9 +21,7 @@ export default function LivePage({
 }) {
   const { page, flags } = data ?? {};
   const manifest = context.manifest!;
-  // TODO: Read this from context
-  const LiveControls = !context.isDeploy &&
-    manifest.islands[`./islands/LiveControls.tsx`]?.default;
+  const LiveControls = manifest.islands[`./islands/LiveControls.tsx`]?.default;
 
   return (
     <>


### PR DESCRIPTION
We don't need to check if we're in production to include the `<LiveControls` island, since its code already hides the component selector:

[Código do LiveControls](https://github.com/deco-cx/live/blob/db5db5c8be254460d1c56534f265520dc3b3a2c9/components/LiveControls.tsx)
<img width="811" alt="image" src="https://user-images.githubusercontent.com/18706156/205344008-57b56343-7445-4471-8383-6b74fb943ade.png">

[Exemplo de loja com essa mudança](https://deco-sites-fashion-62dh7r5h2s60.deno.dev/)