### PR TITLE
feat: Use live-function as function type on json schema

### DIFF
--- a/utils/page.ts
+++ b/utils/page.ts
@@ -36,15 +36,12 @@ export function isValidIsland(componentPath: string) {
   return !BLOCKED_ISLANDS_SCHEMAS.has(componentPath);
 }
 
+/** Property is undefined | boolean | object, so if property[key] is === "object" and $id in property[key] */
 export const propertyHasId = (
   propDefinition: JSONSchema7Definition | undefined,
-) => {
-  // Property is undefined | boolean | object, so if property[key] is === "object" and $id in property[key]
-  return (
-    typeof propDefinition === "object" &&
-    "$id" in (propDefinition as JSONSchema7)
-  );
-};
+): propDefinition is JSONSchema7 => (
+  typeof propDefinition === "object" && "$id" in propDefinition
+);
 
 export const isNotNullOrUndefined = <T extends unknown>(
   item: T | null | undefined,
@@ -125,7 +122,9 @@ export const availableFunctionsForSection = (
   return availableFunctions;
 };
 
-function addUniqueIdToEntity<T extends AvailableFunction | AvailableSection>(
+export function addUniqueIdToEntity<
+  T extends AvailableFunction | AvailableSection,
+>(
   entity: T,
 ): T & { uniqueId: string } {
   return { ...entity, uniqueId: appendHash(entity.key) };

--- a/utils/schema/transform.ts
+++ b/utils/schema/transform.ts
@@ -91,6 +91,8 @@ const schemaForTSBuiltinType = async (node: TypeRef, root: ASTNode[]) => {
 
       return {
         "$id": await getSchemaId(transformed),
+        format: "live-function",
+        type: "string",
       };
     }
   }


### PR DESCRIPTION
This PR adds a new type for function types called `live-function`. With this, we are able to create a custom widget for adding and validating functions on the editor