### PR TITLE
feat: Support literal union

### DIFF
--- a/utils/schema/ast.ts
+++ b/utils/schema/ast.ts
@@ -80,7 +80,16 @@ export type TsType =
   | TsTypeUnion
   | TsTypeIndexedAccess
   | TsTypeTypeLiteral
-  | TsTypeArray;
+  | TsTypeArray
+  | TsTypeLiteral;
+
+export interface TsTypeLiteral {
+  repr: string;
+  kind: "literal";
+  literal: Record<string, string | number | boolean> & {
+    kind: "string" | "number" | "boolean";
+  };
+}
 
 export interface TsTypeArray {
   repr: "";


### PR DESCRIPTION
This PR adds literal union support for live automatic json schema generator

From this version onwards, to create a select on live editor, just:
```tsx
export interface Props {
   selectField: 'one' | 'two'
}
```

This will create a <select> tag on the live editor passing as options the `one` and `two` values