### PR TITLE
fix: format to the right format jsdoc

### DIFF
--- a/utils/schema/transform.ts
+++ b/utils/schema/transform.ts
@@ -139,6 +139,10 @@ export const findExport = (name: string, root: ASTNode[]) => {
   return node;
 };
 
+/** 
+ * Some attriibutes are not string in JSON Schema. Because of that, we need to parse some to boolean or number.
+ * For instance, maxLength and maxItems have to be parsed to number. readOnly should be a boolean etc
+ */
 const parseJSDocAttribute = (key: string, value: string) => {
   switch (key) {
     case "maximum":
@@ -173,7 +177,8 @@ const jsDocToSchema = (node: JSDoc) =>
           const value = match?.groups?.value;
 
           if (typeof key === "string" && typeof value === "string") {
-            return [key, parseJSDocAttribute(key, value)] as const;
+            const parsedValue = parseJSDocAttribute(key, value);
+            return [key, parsedValue] as const;
           }
 
           return null;

--- a/utils/schema/transform.ts
+++ b/utils/schema/transform.ts
@@ -139,6 +139,29 @@ export const findExport = (name: string, root: ASTNode[]) => {
   return node;
 };
 
+const parseJSDocAttribute = (key: string, value: string) => {
+  switch (key) {
+    case "maximum":
+    case "exclusiveMaximum":
+    case "minimum":
+    case "exclusiveMinimum":
+    case "maxLength":
+    case "minLength":
+    case "multipleOf":
+    case "maxItems":
+    case "minItems":
+    case "maxProperties":
+    case "minProperties":
+      return Number(value);
+    case "readOnly":
+    case "writeOnly":
+    case "uniqueItems":
+      return Boolean(value);
+    default:
+      return value;
+  }
+};
+
 const jsDocToSchema = (node: JSDoc) =>
   node.tags
     ? Object.fromEntries(
@@ -150,12 +173,12 @@ const jsDocToSchema = (node: JSDoc) =>
           const value = match?.groups?.value;
 
           if (typeof key === "string" && typeof value === "string") {
-            return [key, value] as const;
+            return [key, parseJSDocAttribute(key, value)] as const;
           }
 
           return null;
         })
-        .filter((e): e is [string, string] => !!e),
+        .filter((e): e is [string, string | number | boolean] => !!e),
     )
     : undefined;
 


### PR DESCRIPTION
This PR makes it possible to declare fixed-length arrays using JSDoc. 

Example: Take the following schema:
```tsx
export interface Props {
  pairs: string[]
}
```

suppose you want to make the `pairs` array to have a fixed length of value 2. To accomplish this, now you can:
```tsx
export interface Props {
  /**
   * @minItems 2
   * @maxItems 2
   */
  pairs: string[]
}
```

It also works if you specify ranges and other. For more info, follow the JSON Schema spec