### PR TITLE
Fix props to use "null" as valid type on non-required types.

### DIFF
--- a/utils/schema/transform.test.ts
+++ b/utils/schema/transform.test.ts
@@ -34,7 +34,7 @@ Deno.test("Non required fields generation", async () => {
     type: "object",
     properties: {
       name: { type: "string", title: "Name" },
-      maybeName: { type: "string", title: "Maybe Name" },
+      maybeName: { type: ["string", "null"], title: "Maybe Name" },
     },
     required: ["name"],
   });
@@ -47,7 +47,7 @@ Deno.test("Union types generation", async () => {
     title: undefined,
     type: "object",
     properties: {
-      name: { anyOf: [{ type: "string" }, { type: "number" }], title: "Name" },
+      name: { anyOf: [{ type: "string" }, { type: "number" }], title: "Name", type: "string"}
     },
     required: ["name"],
   });
@@ -128,8 +128,10 @@ Deno.test("Built in types generation", async () => {
         additionalProperties: { type: "string" },
       },
       loaderReturnType: {
+        format: "live-function",
         "$id": "168110fffa5b1102c412d4eb453091e0cdfc8ba1",
         title: "Loader Return Type",
+        type: "string",
       },
     },
     required: ["array", "record", "loaderReturnType"],

--- a/utils/schema/transform.ts
+++ b/utils/schema/transform.ts
@@ -139,7 +139,7 @@ export const findExport = (name: string, root: ASTNode[]) => {
   return node;
 };
 
-/** 
+/**
  * Some attriibutes are not string in JSON Schema. Because of that, we need to parse some to boolean or number.
  * For instance, maxLength and maxItems have to be parsed to number. readOnly should be a boolean etc
  */
@@ -194,7 +194,7 @@ const typeDefToSchema = async (
   const properties = await Promise.all(
     node.properties.map(async (property) => {
       const jsDocSchema = property.jsDoc && jsDocToSchema(property.jsDoc);
-      const schema = await tsTypeToSchema(property.tsType, root);
+      const schema = await tsTypeToSchema(property.tsType, root, property.optional);
 
       return [property.name, {
         ...schema,
@@ -219,6 +219,7 @@ const typeDefToSchema = async (
 export const tsTypeToSchema = async (
   node: TsType,
   root: ASTNode[],
+  optional?: boolean
 ): Promise<Schema> => {
   const kind = node.kind;
 
@@ -244,7 +245,7 @@ export const tsTypeToSchema = async (
 
     case "keyword": {
       return {
-        type: node.keyword,
+        type: optional ? [node.keyword, "null"] : node.keyword,
       };
     }
 


### PR DESCRIPTION
On a JSON Schema non required types should accept null as a valid (empty) value.