### PR TITLE
fix: editor data respect flag selection

### DIFF
--- a/pages.ts
+++ b/pages.ts
@@ -245,11 +245,9 @@ export function sortRoutes<T extends { pattern: string }>(routes: T[]) {
 export const generateEditorData = async <Data = unknown>(
   req: Request,
   ctx: HandlerContext<Data, LiveState>,
-  pageId: string | null,
+  options: PageOptions
 ): Promise<EditorData> => {
-  const selectedPageIds = pageId ? [Number(pageId)] : [];
-
-  const pageWithParams = await loadLivePage(req, ctx, { selectedPageIds });
+  const pageWithParams = await loadLivePage(req, ctx, options);
 
   if (!pageWithParams) {
     throw new Error("Could not find page to generate editor data");


### PR DESCRIPTION
This PR moves the editorData from the middleware to the page handler. After these changes, adding a `?editorData` to the end of the url, makes the client to receive editorData after flag engine logic