### PR TITLE
feat: persist flags

### DIFF
--- a/flags.ts
+++ b/flags.ts
@@ -7,80 +7,162 @@ import MatchRandom from "$live/functions/MatchRandom.ts";
 import MatchSite from "$live/functions/MatchSite.ts";
 import EffectSelectPage from "$live/functions/EffectSelectPage.ts";
 
+const DECO_COOKIE = "deco_flag_";
+
+export const cookies = {
+  parse: (rawCookies: string | null) => {
+    const flags: CookiedFlag[] | undefined = rawCookies
+      ?.split("; ")
+      .map((c) => c.split("="))
+      .filter((cookie) => cookie[0].startsWith(DECO_COOKIE))
+      .map((cookie) => JSON.parse(atob(cookie[1])));
+
+    if (!flags) {
+      return null;
+    }
+
+    const flagSet = new Map<string, CookiedFlag>();
+    for (const flag of flags) {
+      flagSet.set(flag.key, flag);
+    }
+
+    return flagSet;
+  },
+  format: (flags: CookiedFlag[]) => {
+    return flags.reduce(
+      (acc, flag) =>
+        `${DECO_COOKIE}${flag.key}=${btoa(JSON.stringify(flag))}; ${acc}`,
+      "",
+    );
+  },
+};
+
+interface CookiedFlag {
+  key: string;
+  isMatch: boolean;
+  value: any;
+  timestamp: string;
+}
+
 let flags: Flag[];
 export const flag = (id: string) => flags.find((flag) => flag.id === id);
+
+const runFlagMatchers = <D>(
+  flag: Flag,
+  req: Request,
+  ctx: HandlerContext<D, LiveState>,
+) => {
+  const manifest = context.manifest as DecoManifest;
+  const { data: { matches } } = flag;
+
+  for (const match of matches) {
+    const { key, props } = match;
+
+    const matchFn: MatchFunction<any, any, any> =
+      (key === "$live/functions/MatchRandom.ts")
+        ? MatchRandom
+        : (key === "$live/functions/MatchSite.ts")
+        ? MatchSite
+        : manifest.functions[key]?.default as MatchFunction;
+    // RandomMatch.ts
+    // GradualRolloutMatch.ts
+    // UserIdMatch.ts
+
+    if (!matchFn) {
+      throw new Error("No match function found for key: " + key);
+    }
+
+    const { isMatch, duration } = matchFn(
+      req,
+      ctx,
+      props as any,
+    );
+
+    return { isMatch, duration };
+  }
+};
+
+const runFlagEffect = <D>(
+  flag: Flag,
+  req: Request,
+  ctx: HandlerContext<D, LiveState>,
+) => {
+  const manifest = context.manifest as DecoManifest;
+  const { data: { effect } } = flag;
+
+  const effectFn: EffectFunction<any, any, any> | null = effect
+    ? (effect.key === "$live/functions/EffectSelectPage.ts")
+      ? EffectSelectPage
+      : manifest.functions[effect.key].default as EffectFunction
+    : null;
+
+  return effectFn?.(req, ctx, effect?.props as any) ?? true;
+};
+
+const isCookieExpired = (cookie: CookiedFlag, flag: Flag) => {
+  const { timestamp } = cookie;
+  const { updated_at } = flag;
+
+  return timestamp !== updated_at;
+};
 
 export const loadFlags = async <Data = unknown>(
   req: Request,
   ctx: HandlerContext<Data, LiveState>,
 ) => {
   const site = context.siteId;
-  const manifest = context.manifest as DecoManifest;
 
   // TODO: Cache flags stale for 5 minutes, refresh every 30s
-  const { data: availableFlags, error } = await getSupabaseClient()
+  const response: { data: Flag[]; error: unknown } = await getSupabaseClient()
     .from("flags")
-    .select(
-      `id, name, key, state, data`,
-    )
+    .select(`id, name, key, state, data, updated_at`)
     .eq("site", site)
     .eq("state", "published");
 
-  if (error) {
-    console.log("Error fetching flags:", error);
+  const availableFlags = response.data ?? [];
+
+  if (response.error) {
+    console.log("Error fetching flags:", response.error);
   }
 
-  // TODO: if queryString.flagIds, then activate those flags and skip matching
-  const activeFlags = (availableFlags ?? [])?.filter((flag) => {
-    const { data: { matches } } = flag;
+  const activeFlags: Record<string, unknown> = {};
 
-    for (const match of matches) {
-      const { key, props } = match;
-      const matchFn: MatchFunction<any, any, any> =
-        (key === "$live/functions/MatchRandom.ts")
-          ? MatchRandom
-          : (key === "$live/functions/MatchSite.ts")
-          ? MatchSite
-          : manifest.functions[key]?.default as MatchFunction;
-      // RandomMatch.ts
-      // GradualRolloutMatch.ts
-      // UserIdMatch.ts
-      if (!matchFn) {
-        throw new Error("No match function found for key: " + key);
+  const flagsToCookie: CookiedFlag[] = [];
+  const cookiedFlags = cookies.parse(req.headers.get("cookie"));
+
+  // TODO: if queryString.flagIds, then activate those flags and skip matching
+  for (const flag of availableFlags) {
+    const cookied = cookiedFlags?.get(flag.key);
+
+    // Flag coming from the cookie
+    if (cookied && !isCookieExpired(cookied, flag)) {
+      if (cookied.isMatch) {
+        activeFlags[flag.key] = cookied.value;
       }
-      const { isMatch, duration } = matchFn(
-        req,
-        ctx,
-        props as any,
-      );
-      if (duration === "session") {
-        // TODO: Store in session
-      }
-      if (isMatch) {
-        return true;
-      }
+
+      flagsToCookie.push(cookied);
+
+      continue;
     }
 
-    return false;
-  });
+    // Flag not on cookie or cookie expired, let's run it
+    const matched = runFlagMatchers(flag, req, ctx);
 
-  (activeFlags as Flag[])?.forEach((flag) => {
-    const { data: { effect } } = flag;
+    if (matched) {
+      if (matched.isMatch) {
+        activeFlags[flag.key] = runFlagEffect(flag, req, ctx);
+      }
 
-    const effectFn: EffectFunction<any, any, any> | null = effect
-      ? (effect.key === "$live/functions/EffectSelectPage.ts")
-        ? EffectSelectPage
-        : manifest.functions[effect.key].default as EffectFunction
-      : null;
+      if (matched.duration === "session") {
+        flagsToCookie.push({
+          key: flag.key,
+          isMatch: matched.isMatch,
+          value: activeFlags[flag.key],
+          timestamp: flag.updated_at,
+        });
+      }
+    }
+  }
 
-    flag.value = effectFn?.(req, ctx, effect?.props as any) ?? true;
-  });
-
-  ctx.state.flags = (activeFlags as Flag[])?.reduce((acc, flag) => {
-    acc[flag.key] = flag.value;
-    return acc;
-  }, {} as Record<string, unknown>);
-
-  // TODO: set cookie with flag ids
-  return (activeFlags as Flag[]) ?? [];
+  return { activeFlags, flagsToCookie };
 };

--- a/live.ts
+++ b/live.ts
@@ -145,7 +145,7 @@ export const live: () => Handlers<LivePageData, LiveState> = () => ({
     // Allow introspection of page by editor
     if (url.searchParams.has("editorData")) {
       const editorData = await generateEditorData(req, ctx, pageOptions);
-      
+
       return Response.json(editorData, {
         headers: {
           "Access-Control-Allow-Origin": "*",
@@ -162,7 +162,7 @@ export const live: () => Handlers<LivePageData, LiveState> = () => ({
     const response = await ctx.render({ page, flags: ctx.state.flags });
 
     if (flagsToCookie.length > 0) {
-      response.headers.append("set-cookie", cookies.format(flagsToCookie));
+      cookies.setFlags(response.headers, flagsToCookie);
     }
 
     return response;

--- a/types.ts
+++ b/types.ts
@@ -123,6 +123,7 @@ export interface Flag<T = unknown> {
   site: number;
   key: string;
   value: T;
+  updated_at: string
 }
 
 export interface Flags {


### PR DESCRIPTION
This PR persists flags on cookies by creating one cookie per flag. 

The cookie value is the base64 of the flag object. Also, The mechanism used for invalidating the flag is by checking the last time the flag was updated. If it was updated after the cookie was set, the matcher will be rerun.