### PR TITLE
fix: remove json-schema from deps and import it directly

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,2 +1,1 @@
 export * as supabase from "https://esm.sh/@supabase/supabase-js@2.7.0";
-export * as jsonSchema from "https://esm.sh/@types/json-schema@7.0.11?pin=102";

--- a/dev.ts
+++ b/dev.ts
@@ -12,13 +12,12 @@ import { walk } from "std/fs/walk.ts";
 
 import { setupGithooks } from "https://deno.land/x/githooks@0.0.3/githooks.ts";
 import os from "https://deno.land/x/dos@v0.11.0/mod.ts";
-
-import { jsonSchema } from "./deps.ts";
 import {
   getSchemaFromLoaderExport,
   getSchemaFromSectionExport,
 } from "./utils/schema/utils.ts";
 import { unique } from "./utils/unique.ts";
+import type { JSONSchema } from "./types.ts";
 
 /**
  * This interface represents an intermediate state used to generate
@@ -34,8 +33,8 @@ interface DevManifestData {
   schemas: Record<
     string,
     {
-      inputSchema: jsonSchema.JSONSchema7 | null;
-      outputSchema: jsonSchema.JSONSchema7 | null;
+      inputSchema: JSONSchema | null;
+      outputSchema: JSONSchema | null;
     }
   >;
 }

--- a/types.ts
+++ b/types.ts
@@ -1,8 +1,11 @@
+import { createServerTimings } from "$live/utils/timings.ts";
 import type { HandlerContext } from "$fresh/server.ts";
 import type { IslandModule } from "$fresh/src/server/types.ts";
 import type { Manifest } from "$fresh/server.ts";
-import type { jsonSchema } from "./deps.ts";
-import { createServerTimings } from "$live/utils/timings.ts";
+import type {
+  JSONSchema7,
+  JSONSchema7Definition,
+} from "https://esm.sh/@types/json-schema@7.0.11?pin=v110";
 
 export interface Node {
   label: string;
@@ -11,10 +14,11 @@ export interface Node {
   children?: Node[];
 }
 
-export type Schema = jsonSchema.JSONSchema7;
+export type JSONSchema = JSONSchema7;
+export type JSONSchemaDefinition = JSONSchema7Definition;
 
 export interface Module extends IslandModule {
-  schema?: jsonSchema.JSONSchema7;
+  schema?: JSONSchema;
 }
 
 export interface FunctionModule {
@@ -28,8 +32,8 @@ export interface DecoManifest extends Manifest {
   schemas: Record<
     string,
     {
-      inputSchema: jsonSchema.JSONSchema7 | null;
-      outputSchema: jsonSchema.JSONSchema7 | null;
+      inputSchema: JSONSchema | null;
+      outputSchema: JSONSchema | null;
     }
   >;
 }
@@ -62,7 +66,7 @@ export interface PageSection {
 }
 
 export interface PageFunction extends PageSection {
-  outputSchema?: jsonSchema.JSONSchema7;
+  outputSchema?: JSONSchema;
 }
 
 export interface PageData {
@@ -132,7 +136,7 @@ export interface Flags {
 export type Mode = "edit" | "none";
 
 export interface WithSchema {
-  schema?: jsonSchema.JSONSchema7;
+  schema?: JSONSchema;
 }
 
 export type AvailableSection = Omit<PageSection, "uniqueId"> & WithSchema;

--- a/utils/page.ts
+++ b/utils/page.ts
@@ -1,9 +1,9 @@
-import type { jsonSchema } from "../deps.ts";
-
 import type {
   AvailableFunction,
   AvailableSection,
   EditorData,
+  JSONSchema,
+  JSONSchemaDefinition,
   Page,
   PageData,
   PageSection,
@@ -38,8 +38,8 @@ export function isValidIsland(componentPath: string) {
 
 /** Property is undefined | boolean | object, so if property[key] is === "object" and $id in property[key] */
 export const propertyHasId = (
-  propDefinition: jsonSchema.JSONSchema7Definition | undefined,
-): propDefinition is jsonSchema.JSONSchema7 => (
+  propDefinition: JSONSchemaDefinition | undefined,
+): propDefinition is JSONSchema => (
   typeof propDefinition === "object" && "$id" in propDefinition
 );
 
@@ -279,7 +279,7 @@ export function getMetadataForSectionEditor({
   section: EditorData["sections"][number];
   pageFunctions: EditorData["functions"];
 }): {
-  ownPropsSchema?: jsonSchema.JSONSchema7;
+  ownPropsSchema?: JSONSchema;
   functionsForComponent?: SectionFunction[];
 } {
   const sectionSchema = section.schema;
@@ -313,13 +313,13 @@ export function getMetadataForSectionEditor({
         ...acc,
         [cur]: sectionSchema.properties?.[cur] || {},
       }),
-      {} as jsonSchema.JSONSchema7["properties"],
+      {} as JSONSchema["properties"],
     );
 
   const ownPropsSchema = {
     ...sectionSchema,
     properties: schemaPropertiesWithoutThoseFromLoaders,
-  } as jsonSchema.JSONSchema7;
+  } as JSONSchema;
 
   const functionsForComponent = propsThatMapToLoader
     .map(({ functionUniqueId }) => {

--- a/utils/schema/transform.ts
+++ b/utils/schema/transform.ts
@@ -1,4 +1,4 @@
-import type { Schema } from "$live/types.ts";
+import type { JSONSchema } from "$live/types.ts";
 import type {
   ASTNode,
   ImportDefNode,
@@ -42,7 +42,7 @@ export const denoDoc = async (path: string): Promise<ASTNode[]> => {
   return JSON.parse(stdout);
 };
 
-export const getSchemaId = async (schema: Schema) => {
+export const getSchemaId = async (schema: JSONSchema) => {
   const hashBuffer = await crypto.subtle.digest(
     "SHA-1",
     new TextEncoder().encode(JSON.stringify(schema)),
@@ -190,7 +190,7 @@ const jsDocToSchema = (node: JSDoc) =>
 const typeDefToSchema = async (
   node: TypeDef,
   root: ASTNode[],
-): Promise<Schema> => {
+): Promise<JSONSchema> => {
   const properties = await Promise.all(
     node.properties.map(async (property) => {
       const jsDocSchema = property.jsDoc && jsDocToSchema(property.jsDoc);
@@ -224,7 +224,7 @@ export const tsTypeToSchema = async (
   node: TsType,
   root: ASTNode[],
   optional?: boolean,
-): Promise<Schema> => {
+): Promise<JSONSchema> => {
   const kind = node.kind;
 
   switch (kind) {
@@ -287,7 +287,7 @@ export const tsTypeToSchema = async (
   }
 };
 
-const docToSchema = async (node: ASTNode, root: ASTNode[]): Promise<Schema> => {
+const docToSchema = async (node: ASTNode, root: ASTNode[]): Promise<JSONSchema> => {
   const kind = node.kind;
 
   switch (kind) {

--- a/utils/schema/utils.ts
+++ b/utils/schema/utils.ts
@@ -5,7 +5,7 @@ import {
   getSchemaId,
   tsTypeToSchema,
 } from "./transform.ts";
-import { Schema } from "$live/types.ts";
+import { JSONSchema } from "$live/types.ts";
 import { basename } from "std/path/mod.ts";
 
 const withErrorPath = <T>(cb: (x: string) => T) => async (path: string) => {
@@ -81,7 +81,7 @@ export const getSchemaFromLoaderExport = withErrorPath(async (path: string) => {
 
   const inputSchema = propType && await tsTypeToSchema(propType, nodes);
   const outputType = returnType && await tsTypeToSchema(returnType, nodes);
-  const outputSchema: Schema | null = outputType && {
+  const outputSchema: JSONSchema | null = outputType && {
     type: "object",
     properties: {
       data: {
@@ -103,7 +103,7 @@ export const getSchemaFromLoaderExport = withErrorPath(async (path: string) => {
 });
 
 // TODO: Should we extract defaultProps from the schema here?
-export const generatePropsForSchema = (schema: Schema | null | undefined) => {
+export const generatePropsForSchema = (schema: JSONSchema | null | undefined) => {
   if (schema?.type == null || Array.isArray(schema.type)) {
     return null;
   }


### PR DESCRIPTION
After #106, deco-sites/deco stopped working with an error saying json-schema is of unknown type `dts`. This PR addresses this issue by importing only necessary types from json-schema and re-exporting them as our version of JSONSchema. 