### PR TITLE
feat: Add header response side effect to loaders

### DIFF
--- a/pages.ts
+++ b/pages.ts
@@ -297,7 +297,11 @@ export const loadPage = async <Data = unknown>(
   const { page, params = {} } = pageWithParams;
 
   start("load-data");
-  const pageDataAfterFunctions = await loadPageData(
+  const {
+    pageData: pageDataAfterFunctions,
+    headers,
+    status,
+  } = await loadPageData(
     req,
     {
       ...ctx,
@@ -308,7 +312,12 @@ export const loadPage = async <Data = unknown>(
   end("load-data");
 
   ctx.state.page = { ...page, data: pageDataAfterFunctions };
-  return ctx.state.page;
+  
+  return {
+    page: ctx.state.page,
+    headers,
+    status,
+  };
 };
 
 const loadGlobal = ({ globalSettings }: { globalSettings: Page[] }) => {

--- a/utils/http.ts
+++ b/utils/http.ts
@@ -1,0 +1,136 @@
+export const DEFAULT_CACHE_CONTROL: CacheControl = {
+  "s-maxage": 60, // 1minute cdn cache
+  "max-age": 0, // 0s browser cache
+  "stale-while-revalidate": 3600, // 1hour
+  "stale-if-error": 24 * 3600, // 1day
+  public: true,
+};
+
+export type CacheControl = Partial<{
+  "max-age": number;
+  "s-maxage": number;
+  "stale-while-revalidate": number;
+  "stale-if-error": number;
+  "public": boolean;
+  "private": boolean;
+  "no-cache": boolean;
+  "no-store": boolean;
+  "must-revalidate": boolean;
+  "proxy-revalidate": boolean;
+  "immutable": boolean;
+  "no-transform": boolean;
+}>;
+
+const parseCacheControlSegment = (
+  segment: string,
+): CacheControl => {
+  const [key, value] = segment.trim().split("=");
+
+  switch (key) {
+    case "max-age":
+      return { [key]: Number(value) };
+    case "s-maxage":
+      return { [key]: Number(value) };
+    case "stale-while-revalidate":
+      return { [key]: Number(value) };
+    case "stale-if-error":
+      return { [key]: Number(value) };
+    case "public":
+      return { [key]: true };
+    case "private":
+      return { [key]: true };
+    case "no-cache":
+      return { [key]: true };
+    case "no-store":
+      return { [key]: true };
+    case "must-revalidate":
+      return { [key]: true };
+    case "proxy-revalidate":
+      return { [key]: true };
+    case "immutable":
+      return { [key]: true };
+    case "no-transform":
+      return { [key]: true };
+  }
+
+  throw new Error(`Unknown cache directive ${value}`);
+};
+
+export const parseVary = (headers: Headers): string[] => {
+  const value = headers.get("vary");
+
+  return value?.split(",").map((x) => x.trim()) ?? [];
+};
+
+export const formatVary = (vary: string[]) => vary.filter(Boolean).join(", ");
+
+export const parseCacheControl = (headers: Headers): CacheControl => {
+  const value = headers.get("cache-control");
+
+  return value
+    ?.split(",")
+    .map((x) => x.trim())
+    .reduce(
+      (acc, curr) => ({
+        ...parseCacheControlSegment(curr),
+        ...acc,
+      }),
+      {} as CacheControl,
+    ) ?? {};
+};
+
+export const formatCacheControl = (value: CacheControl) =>
+  Object
+    .entries(value)
+    .map(([key, value]) =>
+      value === true
+        ? key
+        : typeof value === "number"
+        ? `${key}=${value}`
+        : undefined
+    )
+    .filter(Boolean)
+    .join(", ");
+
+const min = (a?: number, b?: number) =>
+  typeof a === "number" && typeof b === "number"
+    ? (a < b ? a : b)
+    : typeof a === "number"
+    ? a
+    : b;
+
+export const mergeCacheControl = (
+  h1: CacheControl,
+  h2: CacheControl,
+): CacheControl => {
+  const maxAge = min(h1["max-age"], h2["max-age"]);
+  const sMaxAge = min(h1["s-maxage"], h2["s-maxage"]);
+  const staleWhileRevalidate = min(
+    h1["stale-while-revalidate"],
+    h2["stale-while-revalidate"],
+  );
+  const staleIfError = min(h1["stale-if-error"], h2["stale-if-error"]);
+  const pub = h1["public"] || h2["public"];
+  const pvt = h1["public"] || h2["public"];
+  const noCache = h1["no-cache"] || h2["no-cache"];
+  const noStore = h1["no-store"] || h2["no-store"];
+  const mustRevalidate = h1["must-revalidate"] || h2["must-revalidate"];
+  const proxyRevalidate = h1["proxy-revalidate"] || h2["proxy-revalidate"];
+  const immutable = h1["immutable"] && h2["immutable"];
+  const noTransform = h1["no-transform"] || h2["no-transform"];
+
+  return {
+    "max-age": maxAge,
+    "s-maxage": sMaxAge,
+    "stale-while-revalidate": staleWhileRevalidate,
+    "stale-if-error": staleIfError,
+    "public": pub && !pvt,
+    "private": pvt,
+    "no-cache": noCache,
+    "no-store": noStore,
+    "must-revalidate": mustRevalidate,
+    "proxy-revalidate": proxyRevalidate,
+    "immutable": immutable,
+    "no-transform": noTransform,
+  };
+};


### PR DESCRIPTION
## What's the purpose of this PR?
This PR allows loaders to return headers and status. These headers and statuses are merged following an heuristic. The only headers allowed are cache-control and vary headers. 

## How it works? 
When multiple loaders return a cache-control header on the same page, their cache-control headers must be merged. We use the more specific value first. This means that if we have two loaders returning two different cache-control headers, say `max-age=60, public, stale-while-revalidate=60` and `max-age=0, private, must-revalidate`, the final cache-control header should be `max-age=0, private, must-revalidate, stale-while-revalidate=60`

This PR adds a default cache-control to all pages: `max-age=0, s-maxage=60, public, stale-while-revalidate=3600, stale-if-error: 86400`. This value will change in case a loader returns a custom cache-control header

Also, status and vary cache headers are set. Status follows `max(loader1, loader2, 200)` logic and vary is the `join(loader1, loader2)`

